### PR TITLE
Allow floating label for TextInput widget with "date" type

### DIFF
--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -286,7 +286,7 @@ class FieldRenderer(BaseRenderer):
     def can_widget_float(self, widget):
         """Return whether given widget can be set to `form-floating` behavior."""
         if isinstance(widget, (TextInput, NumberInput, EmailInput, URLInput, PasswordInput)):
-            return self.get_widget_input_type(widget) in ["text", "number", "email", "url", "password"]
+            return self.get_widget_input_type(widget) in ["text", "number", "email", "url", "password", "date"]
         if isinstance(widget, Textarea):
             return True
         if isinstance(widget, Select):


### PR DESCRIPTION
Django by default does not use the `date` input type (the `DateInput` widgets renders a `text` input). I use a custom widget like this to have a date picker in most browsers without much effort:

```
class DatePickerInput(forms.DateInput):
    input_type = "date"
```

This input type is not rendered with floating labels currently, although it works:

![grafik](https://user-images.githubusercontent.com/1931925/115971074-c36e1f80-a546-11eb-842f-83604161e7ed.png)

This pull request simply adds `date` to the list of accepted types for floating labels. Not sure if you want to merge it like this ;)

Another - probably more clean solution - could be a setting to define custom widgets that support floating labels?

Thanks for your work on this module!
