### PR TITLE
Remove text_value() from render_tag()

### DIFF
--- a/src/django_bootstrap5/html.py
+++ b/src/django_bootstrap5/html.py
@@ -1,7 +1,6 @@
 from django.forms.utils import flatatt
 from django.utils.html import format_html
 
-from django_bootstrap5.text import text_value
 from django_bootstrap5.utils import get_url_attrs
 
 
@@ -21,7 +20,6 @@ def render_tag(tag, attrs=None, content=None, close=True):
     """Render an HTML tag."""
     attrs_string = flatatt(attrs) if attrs else ""
     builder = "<{tag}{attrs}>{content}"
-    content_string = text_value(content)
-    if content_string or close:
+    if content or close:
         builder += "</{tag}>"
-    return format_html(builder, tag=tag, attrs=attrs_string, content=content_string)
+    return format_html(builder, tag=tag, attrs=attrs_string, content=content)


### PR DESCRIPTION
`text_value` turns safe strings into unsafe string (#140). Seeing that the string is about to be passed into `format_html`, I think it is not necessary as `format_html` should know how to turn content into string and will correctly handle safe/unsafe strings.