### PR TITLE
Pass message's string to bootstrap_alert instead of Message obj

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/messages.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/messages.html
@@ -1,4 +1,4 @@
 {% load django_bootstrap5 %}
 {% for message in messages %}
-    {% bootstrap_alert message|default:"" alert_type=message|bootstrap_message_alert_type extra_classes=message.extra_tags %}
+    {% bootstrap_alert message.message|default:"" alert_type=message|bootstrap_message_alert_type extra_classes=message.extra_tags %}
 {% endfor %}


### PR DESCRIPTION
Addresses issue #140 by passing safe string to `bootstrap_alert` templatetag