### PR TITLE
Handle safe strings in bootstrap_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## In development
+
+- Respect safe strings in bootstrap_messages (#145).
+
 ## [2.1.0] - 2021-07-11
 
 - Bump Bootstrap from 5.0.1 to 5.0.2 (#138).

--- a/src/django_bootstrap5/templates/django_bootstrap5/messages.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/messages.html
@@ -1,4 +1,4 @@
 {% load django_bootstrap5 %}
 {% for message in messages %}
-    {% bootstrap_alert message|default:"" alert_type=message|bootstrap_message_alert_type extra_classes=message.extra_tags %}
+    {% bootstrap_alert message.message|default:"" alert_type=message|bootstrap_message_alert_type extra_classes=message.extra_tags %}
 {% endfor %}

--- a/tests/test_bootstrap_messages.py
+++ b/tests/test_bootstrap_messages.py
@@ -1,5 +1,6 @@
 from django.contrib.messages import constants as DEFAULT_MESSAGE_LEVELS
 from django.contrib.messages.storage.base import Message
+from django.utils.safestring import mark_safe
 
 from tests.base import BootstrapTestCase
 
@@ -49,6 +50,15 @@ class MessagesTestCase(BootstrapTestCase):
         self.assertHTMLEqual(
             self.render("{% bootstrap_messages messages %}", {"messages": messages}),
             self._html(content="hello there", css_class="alert-danger"),
+        )
+
+    def test_bootstrap_messages_with_safe_message(self):
+        messages = [Message(DEFAULT_MESSAGE_LEVELS.INFO, mark_safe("Click <a href='https://www.github.com/'>here</a>"))]
+        html = self.render("{% bootstrap_messages messages %}", {"messages": messages})
+        print(html)
+        self.assertHTMLEqual(
+            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self._html(content="Click <a href='https://www.github.com/'>here</a>", css_class="alert-info"),
         )
 
     def test_bootstrap_messages_with_invalid_message(self):


### PR DESCRIPTION
Fixes: #140

Thanks @mick88, solution taken from #142 