### PR TITLE
Fix "disabled" parameter for RadioSelect and CheckboxSelectMultiple

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
@@ -11,7 +11,8 @@
                        name="{{ option.name }}"
                        id="{{ option.attrs.id }}"
                         {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"
-                            {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}>
+                            {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}
+                        {% if widget.attrs.disabled %} disabled{% endif %}>
                 <label class="form-check-label" for="{{ option.attrs.id }}">{{ option.label }}</label>
             </div>
         {% endfor %}


### PR DESCRIPTION
The `disabled` attribute ist not set for input fields in `radio_select.html`. Therefore, the `RadioSelect` and `CheckboxSelectMultiple` widgets ignore the `disabled` parameter.