### PR TITLE
Force keyword arguments

### DIFF
--- a/src/django_bootstrap5/components.py
+++ b/src/django_bootstrap5/components.py
@@ -9,7 +9,13 @@ from .size import DEFAULT_SIZE, SIZE_MD, get_size_class
 ALERT_TYPES = ["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
 
 
-def render_alert(content, alert_type="info", dismissible=True, extra_classes=""):
+def render_alert(
+    content,
+    *,
+    alert_type="info",
+    dismissible=True,
+    extra_classes="",
+):
     """Render a Bootstrap alert."""
     button = ""
     if alert_type not in ALERT_TYPES:
@@ -29,6 +35,7 @@ def render_alert(content, alert_type="info", dismissible=True, extra_classes="")
 
 def render_button(
     content,
+    *,
     button_type=None,
     button_class="btn-primary",
     size="",

--- a/src/django_bootstrap5/forms.py
+++ b/src/django_bootstrap5/forms.py
@@ -20,7 +20,7 @@ def render_form(form, **kwargs):
     return renderer_cls(form, **kwargs).render()
 
 
-def render_form_errors(form, type="all", **kwargs):
+def render_form_errors(form, *, type="all", **kwargs):
     """Render form errors to a Bootstrap layout."""
     renderer_cls = get_form_renderer(**kwargs)
     return renderer_cls(form, **kwargs).render_errors(type)
@@ -32,7 +32,13 @@ def render_field(field, **kwargs):
     return renderer_cls(field, **kwargs).render()
 
 
-def render_label(content, label_for=None, label_class=None, label_title=""):
+def render_label(
+    content,
+    *,
+    label_for=None,
+    label_class=None,
+    label_title="",
+):
     """Render a label with content."""
     attrs = {}
     if label_for:

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -25,7 +25,7 @@ from .widgets import ReadOnlyPasswordHashWidget, is_widget_with_placeholder
 class BaseRenderer:
     """A content renderer."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.layout = kwargs.get("layout", "")
         self.wrapper_class = kwargs.get("wrapper_class", get_bootstrap_setting("wrapper_class"))
         self.inline_wrapper_class = kwargs.get("inline_wrapper_class", get_bootstrap_setting("inline_wrapper_class"))
@@ -107,11 +107,11 @@ class BaseRenderer:
 class FormsetRenderer(BaseRenderer):
     """Default formset renderer."""
 
-    def __init__(self, formset, *args, **kwargs):
+    def __init__(self, formset, **kwargs):
         if not isinstance(formset, BaseFormSet):
             raise TypeError('Parameter "formset" should contain a valid Django Formset.')
         self.formset = formset
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def render_management_form(self):
         """Return HTML for management form."""
@@ -147,11 +147,11 @@ class FormsetRenderer(BaseRenderer):
 class FormRenderer(BaseRenderer):
     """Default form renderer."""
 
-    def __init__(self, form, *args, **kwargs):
+    def __init__(self, form, **kwargs):
         if not isinstance(form, BaseForm):
             raise TypeError('Parameter "form" should contain a valid Django Form.')
         self.form = form
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def render_fields(self):
         rendered_fields = mark_safe("")
@@ -193,11 +193,11 @@ class FormRenderer(BaseRenderer):
 class FieldRenderer(BaseRenderer):
     """Default field renderer."""
 
-    def __init__(self, field, *args, **kwargs):
+    def __init__(self, field, **kwargs):
         if not isinstance(field, BoundField):
             raise TypeError('Parameter "field" should contain a valid Django BoundField.')
         self.field = field
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
         self.widget = field.field.widget
         self.is_multi_widget = isinstance(field.field.widget, MultiWidget)

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -214,7 +214,7 @@ def bootstrap_javascript():
 
 
 @register.simple_tag
-def bootstrap_formset(*args, **kwargs):
+def bootstrap_formset(formset, **kwargs):
     """
     Render a formset.
 
@@ -238,11 +238,11 @@ def bootstrap_formset(*args, **kwargs):
 
         {% bootstrap_formset formset layout='horizontal' %}
     """
-    return render_formset(*args, **kwargs)
+    return render_formset(formset, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_formset_errors(*args, **kwargs):
+def bootstrap_formset_errors(formset, **kwargs):
     """
     Render formset errors.
 
@@ -266,11 +266,11 @@ def bootstrap_formset_errors(*args, **kwargs):
 
         {% bootstrap_formset_errors formset layout='inline' %}
     """
-    return render_formset_errors(*args, **kwargs)
+    return render_formset_errors(formset, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_form(*args, **kwargs):
+def bootstrap_form(form, **kwargs):
     """
     Render a form.
 
@@ -308,11 +308,11 @@ def bootstrap_form(*args, **kwargs):
 
         {% bootstrap_form form layout='inline' %}
     """
-    return render_form(*args, **kwargs)
+    return render_form(form, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_form_errors(*args, **kwargs):
+def bootstrap_form_errors(form, **kwargs):
     """
     Render form errors.
 
@@ -347,11 +347,11 @@ def bootstrap_form_errors(*args, **kwargs):
 
         {% bootstrap_form_errors form layout='inline' %}
     """
-    return render_form_errors(*args, **kwargs)
+    return render_form_errors(form, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_field(*args, **kwargs):
+def bootstrap_field(field, **kwargs):
     """
     Render a field.
 
@@ -480,11 +480,11 @@ def bootstrap_field(*args, **kwargs):
 
         {% bootstrap_field field show_label=False %}
     """
-    return render_field(*args, **kwargs)
+    return render_field(field, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_label(*args, **kwargs):
+def bootstrap_label(content, **kwargs):
     """
     Render a label.
 
@@ -514,11 +514,11 @@ def bootstrap_label(*args, **kwargs):
 
         {% bootstrap_label "Email address" label_for="exampleInputEmail1" %}
     """
-    return render_label(*args, **kwargs)
+    return render_label(content, **kwargs)
 
 
 @register.simple_tag
-def bootstrap_button(*args, **kwargs):
+def bootstrap_button(content, **kwargs):
     """
     Render a button.
 
@@ -582,7 +582,7 @@ def bootstrap_button(*args, **kwargs):
 
         {% bootstrap_button "Save" button_type="submit" button_class="btn-primary" %}
     """
-    return render_button(*args, **kwargs)
+    return render_button(content, **kwargs)
 
 
 @register.simple_tag

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -629,7 +629,7 @@ def bootstrap_alert(content, **kwargs):
 
 
 @register.simple_tag(takes_context=True)
-def bootstrap_messages(context, *args, **kwargs):
+def bootstrap_messages(context):
     """
     Show django.contrib.messages Messages in Bootstrap alert containers.
 

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -720,7 +720,14 @@ def bootstrap_url_replace_param(url, name, value):
 
 
 def get_pagination_context(
-    page, pages_to_show=11, url=None, size=None, justify_content=None, extra=None, parameter_name="page"
+    page,
+    *,
+    pages_to_show=11,
+    url=None,
+    size=None,
+    justify_content=None,
+    extra=None,
+    parameter_name="page",
 ):
     """Generate Bootstrap pagination context from a page object."""
     pages_to_show = int(pages_to_show)

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -586,7 +586,7 @@ def bootstrap_button(content, **kwargs):
 
 
 @register.simple_tag
-def bootstrap_alert(content, alert_type="info", dismissible=True, extra_classes=""):
+def bootstrap_alert(content, **kwargs):
     """
     Render an alert.
 
@@ -625,7 +625,7 @@ def bootstrap_alert(content, alert_type="info", dismissible=True, extra_classes=
 
         {% bootstrap_alert "Something went wrong" alert_type="error" %}
     """
-    return render_alert(content, alert_type, dismissible, extra_classes)
+    return render_alert(content, **kwargs)
 
 
 @register.simple_tag(takes_context=True)

--- a/tests/test_bootstrap_messages.py
+++ b/tests/test_bootstrap_messages.py
@@ -17,51 +17,51 @@ class MessagesTestCase(BootstrapTestCase):
     def test_bootstrap_messages(self):
         messages = [Message(DEFAULT_MESSAGE_LEVELS.WARNING, "hello")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello", css_class="alert-warning"),
         )
 
         messages = [Message(DEFAULT_MESSAGE_LEVELS.ERROR, "hello")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello", css_class="alert-danger"),
         )
 
     def test_bootstrap_messages_with_other_levels(self):
         messages = [Message(DEFAULT_MESSAGE_LEVELS.INFO, "hello")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello", css_class="alert-info"),
         )
         messages = [Message(999, "hello")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello", css_class="alert-info"),
         )
 
     def test_bootstrap_messages_with_other_content(self):
         messages = [Message(DEFAULT_MESSAGE_LEVELS.ERROR, "hello http://example.com")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello http://example.com", css_class="alert-danger"),
         )
 
         messages = [Message(DEFAULT_MESSAGE_LEVELS.ERROR, "hello\nthere")]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="hello there", css_class="alert-danger"),
         )
 
     def test_bootstrap_messages_with_safe_message(self):
         messages = [Message(DEFAULT_MESSAGE_LEVELS.INFO, mark_safe("Click <a href='https://www.github.com/'>here</a>"))]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="Click <a href='https://www.github.com/'>here</a>", css_class="alert-info"),
         )
 
     def test_bootstrap_messages_with_invalid_message(self):
         messages = [None]
         self.assertHTMLEqual(
-            self.render("{% bootstrap_messages messages %}", {"messages": messages}),
+            self.render("{% bootstrap_messages %}", {"messages": messages}),
             self._html(content="", css_class="alert-info"),
         )


### PR DESCRIPTION
Probably due to Legacy Reasons, the renderer classes (and their wrapper functions) accept `*args`, but they tend to just throw those args on the floor. As such it's better to not even allow positional kwargs.