### PR TITLE
make addon_before_class and addon_after_class effective

### DIFF
--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -489,11 +489,11 @@ class FieldRenderer(BaseRenderer):
 
         if self.is_form_control_widget():
             addon_before = self.addon_before
-            if self.addon_before_class is not None:
+            if addon_before and self.addon_before_class is not None:
                 addon_before = format_html('<span class="{}">{}</span>', self.addon_before_class, addon_before)
 
             addon_after = self.addon_after
-            if self.addon_after_class is not None:
+            if addon_after and self.addon_after_class is not None:
                 addon_after = format_html('<span class="{}">{}</span>', self.addon_after_class, addon_after)
 
             if addon_before or addon_after:

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -488,12 +488,14 @@ class FieldRenderer(BaseRenderer):
         errors = self.get_errors_html()
 
         if self.is_form_control_widget():
-            addon_before = (
-                format_html('<span class="input-group-text">{}</span>', self.addon_before) if self.addon_before else ""
-            )
-            addon_after = (
-                format_html('<span class="input-group-text">{}</span>', self.addon_after) if self.addon_after else ""
-            )
+            addon_before = self.addon_before
+            if self.addon_before_class is not None:
+                addon_before = format_html('<span class="{}">{}</span>', self.addon_before_class, addon_before)
+
+            addon_after = self.addon_after
+            if self.addon_after_class is not None:
+                addon_after = format_html('<span class="{}">{}</span>', self.addon_after_class, addon_after)
+
             if addon_before or addon_after:
                 classes = "input-group"
                 if self.server_side_validation and self.get_server_side_validation_classes():


### PR DESCRIPTION
`addon_before_class` and `addon_after_class` don't take effect as per its [document](https://github.com/zostera/django-bootstrap5/blob/020535210d6664537d4c7d1bdf89597cdf7a92f7/src/django_bootstrap5/templatetags/django_bootstrap5.py#L436):

```
        addon_before_class
            Class used on the span when ``addon_before`` is used.

            One of the following values:

                * ``'input-group-text'``
                * ``None``

            Set to None to disable the span inside the addon. (for use with buttons)

            :default: ``input-group-text``

        addon_after_class
            Class used on the span when ``addon_after`` is used.

            One of the following values:

                * ``'input-group-text'``
                * ``None``

            Set to None to disable the span inside the addon. (for use with buttons)

            :default: ``input-group-text``
```

So this PR added code for it.