### PR TITLE
update radio_select_button_group widget to BS5

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select_button_group.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select_button_group.html
@@ -1,10 +1,8 @@
-{% load django_bootstrap5 %}
-<div{% if widget.attrs.id %} id="{{ widget.attrs.id }}"{% endif %} class="btn-group btn-group-toggle" data-toggle="buttons">
-    {% for group, options, index in widget.optgroups %}
-        {% for option in options %}
-            <label class="{{ widget.attrs.class|add:' btn btn-outline-primary' }}{% if option.attrs.checked %} active{% endif %}" id="{{ widget.attrs.id }}">
-                <input type="{{ option.type }}" name="{{ option.name }}" id="{{ option.attrs.id }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}{% if widget.required %} required{% endif %}> {{ option.label }}
-            </label>
-        {% endfor %}
+<div{% if widget.attrs.id %} id="{{ widget.attrs.id }}"{% endif %} class="btn-group" role="group">
+  {% for group, options, index in widget.optgroups %}
+    {% for option in options %}
+      <input type="{{ option.type }}" class="{{ widget.attrs.class|add:' btn-check' }}" autocomplete="off" name="{{ option.name }}" id="{{ option.attrs.id }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}{% if widget.required %} required{% endif %}>
+      <label class="btn btn-outline-primary" for="{{ option.attrs.id }}">{{ option.label }}</label>
     {% endfor %}
+  {% endfor %}
 </div>


### PR DESCRIPTION
fixes #111

untested, but should work.
I wrote this patch for [django-bootstrap-v5](https://github.com/zelenij/django-bootstrap-v5/issues/27), and I don't know why there are 2 projects. Is there a possibility to merge?