### PR TITLE
Drop support for Django 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 22.1 (in development)
 
 - Add support for Django 4.1.
+- Drop support for Django 2.2.
 
 ## 21.3 (2021-12-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 22.1 (in development)
 
 - Add support for Django 4.1.
-- Drop support for Django 2.2.
+- Drop support for Django 2.2 (EOL).
 
 ## 21.3 (2021-12-27)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ready for production. Issues and pull requests welcome, see [CONTRIBUTING.md](CO
 
 ## Requirements
 
-Python 3.7 or newer with Django >= 2.2 or newer.
+Python 3.7 or newer with Django >= 3.2 or newer.
 
 ## Documentation
 
@@ -30,7 +30,7 @@ The full documentation is at https://django-bootstrap5.readthedocs.io/
     ```bash
     pip install django-bootstrap5
     ```
-    
+
 2. Add to `INSTALLED_APPS` in your `settings.py`:
 
    ```python

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ready for production. Issues and pull requests welcome, see [CONTRIBUTING.md](CO
 
 ## Requirements
 
-Python 3.7 or newer with Django >= 3.2 or newer.
+Python 3.7 or newer with Django 3.2 or newer.
 
 ## Documentation
 

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
 ..
-django>=2.2
+django>=3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -34,7 +34,7 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    Django>=2.2
+    Django>=3.2
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ setenv =
 commands =
     coverage run --parallel-mode manage.py test -v1 --noinput
 deps =
-    django22: Django==2.2.*
     django32: Django==3.2.*
     django40: Django==4.0.*
     django41: Django==4.1.*


### PR DESCRIPTION
- Update tox
- Update setup.cfg
- Update CHANGELOG

Also fixes PyPI classifiers for Django 4.1