### PR TITLE
Fix RadioSelectButtonGroup rendering and add 'disabled' attribute to radio button group template

### DIFF
--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -19,7 +19,7 @@ from .forms import render_field, render_form, render_label
 from .size import DEFAULT_SIZE, SIZE_MD, get_size_class, parse_size
 from .text import text_value
 from .utils import render_template_file
-from .widgets import ReadOnlyPasswordHashWidget, is_widget_with_placeholder
+from .widgets import RadioSelectButtonGroup, ReadOnlyPasswordHashWidget, is_widget_with_placeholder
 
 
 class BaseRenderer:
@@ -347,7 +347,8 @@ class FieldRenderer(BaseRenderer):
         for widget in widgets:
             self.add_widget_class_attrs(widget)
             self.add_placeholder_attrs(widget)
-            if isinstance(widget, (RadioSelect, CheckboxSelectMultiple)):
+            if (isinstance(widget, (RadioSelect, CheckboxSelectMultiple))
+                    and not isinstance(widget, RadioSelectButtonGroup)):
                 widget.template_name = "django_bootstrap5/widgets/radio_select.html"
             elif isinstance(widget, ClearableFileInput):
                 widget.template_name = "django_bootstrap5/widgets/clearable_file_input.html"

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -347,8 +347,9 @@ class FieldRenderer(BaseRenderer):
         for widget in widgets:
             self.add_widget_class_attrs(widget)
             self.add_placeholder_attrs(widget)
-            if (isinstance(widget, (RadioSelect, CheckboxSelectMultiple))
-                    and not isinstance(widget, RadioSelectButtonGroup)):
+            if isinstance(widget, (RadioSelect, CheckboxSelectMultiple)) and not isinstance(
+                widget, RadioSelectButtonGroup
+            ):
                 widget.template_name = "django_bootstrap5/widgets/radio_select.html"
             elif isinstance(widget, ClearableFileInput):
                 widget.template_name = "django_bootstrap5/widgets/clearable_file_input.html"

--- a/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select_button_group.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select_button_group.html
@@ -1,7 +1,15 @@
 <div{% if widget.attrs.id %} id="{{ widget.attrs.id }}"{% endif %} class="btn-group" role="group">
   {% for group, options, index in widget.optgroups %}
     {% for option in options %}
-      <input type="{{ option.type }}" class="{{ widget.attrs.class|add:' btn-check' }}" autocomplete="off" name="{{ option.name }}" id="{{ option.attrs.id }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}{% if widget.required %} required{% endif %}>
+      <input type="{{ option.type }}"
+             class="{{ widget.attrs.class|add:' btn-check' }}"
+             autocomplete="off"
+             name="{{ option.name }}"
+             id="{{ option.attrs.id }}"
+             {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"
+              {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}
+             {% if widget.attrs.disabled %} disabled{% endif %}
+             {% if widget.required %} required{% endif %}>
       <label class="btn btn-outline-primary" for="{{ option.attrs.id }}">{{ option.label }}</label>
     {% endfor %}
   {% endfor %}

--- a/tests/test_bootstrap_field_radio_select_button_group.py
+++ b/tests/test_bootstrap_field_radio_select_button_group.py
@@ -1,0 +1,99 @@
+from django import forms
+
+from django_bootstrap5.widgets import RadioSelectButtonGroup
+
+from .base import BootstrapTestCase
+
+
+class SelectTestForm(forms.Form):
+    test = forms.ChoiceField(
+        choices=(
+            (1, "one"),
+            (2, "two"),
+        ),
+        widget=RadioSelectButtonGroup,
+    )
+
+
+class DisabledSelectTestForm(forms.Form):
+    test = forms.ChoiceField(
+        choices=(
+            (1, "one"),
+            (2, "two"),
+        ),
+        widget=RadioSelectButtonGroup,
+        disabled=True,
+    )
+
+
+class BootstrapFieldSelectTestCase(BootstrapTestCase):
+    def test_select(self):
+        """Test field with select widget."""
+        self.assertHTMLEqual(
+            self.render("{% bootstrap_field form.test %}", context={"form": SelectTestForm()}),
+            (
+                '<div class="django_bootstrap5-req mb-3">'
+                '<label class="form-label">Test</label>'
+                '<div id="id_test" class="btn-group" role="group">'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
+                '</div>'
+                "</div>"
+            ),
+        )
+
+    def test_select_horizontal(self):
+        """Test field with select widget in horizontal layout."""
+        self.assertHTMLEqual(
+            self.render('{% bootstrap_field form.test layout="horizontal" %}', context={"form": SelectTestForm()}),
+            (
+                '<div class="django_bootstrap5-req row mb-3">'
+                '<label class="col-sm-2 col-form-label">Test</label>'
+                '<div class="col-sm-10">'
+                '<div id="id_test" class="btn-group" role="group">'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
+                '</div>'
+                "</div>"
+                "</div>"
+            ),
+        )
+
+    def test_select_floating(self):
+        """Test field with select widget in floating layout."""
+        self.assertHTMLEqual(
+            self.render('{% bootstrap_field form.test layout="floating" %}', context={"form": SelectTestForm()}),
+            (
+                '<div class="django_bootstrap5-req mb-3">'
+                '<label class="form-label">Test</label>'
+                '<div id="id_test" class="btn-group" role="group">'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
+                '</div>'
+                "</div>"
+            ),
+        )
+
+    def test_disabled_select(self):
+        """Test field with disabled select widget."""
+        self.maxDiff = None
+        self.assertHTMLEqual(
+            self.render("{% bootstrap_field form.test %}", context={"form": DisabledSelectTestForm()}),
+            (
+                '<div class="django_bootstrap5-req mb-3">'
+                '<label class="form-label">Test</label>'
+                '<div id="id_test" class="btn-group" role="group">'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" disabled required>'
+                '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" disabled required>'
+                '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
+                '</div>'
+                "</div>"
+            ),
+        )

--- a/tests/test_bootstrap_field_radio_select_button_group.py
+++ b/tests/test_bootstrap_field_radio_select_button_group.py
@@ -35,11 +35,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
                 '<div id="id_test" class="btn-group" role="group">'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
-                '</div>'
+                "</div>"
                 "</div>"
             ),
         )
@@ -53,11 +55,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 '<label class="col-sm-2 col-form-label">Test</label>'
                 '<div class="col-sm-10">'
                 '<div id="id_test" class="btn-group" role="group">'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
-                '</div>'
+                "</div>"
                 "</div>"
                 "</div>"
             ),
@@ -71,11 +75,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
                 '<div id="id_test" class="btn-group" role="group">'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" '
+                "required>"
                 '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
-                '</div>'
+                "</div>"
                 "</div>"
             ),
         )
@@ -89,11 +95,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
                 '<div id="id_test" class="btn-group" role="group">'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" disabled required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_0" value="1" '
+                "disabled required>"
                 '<label class="btn btn-outline-primary" for="id_test_0">one</label>'
-                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" disabled required>'
+                '<input type="radio" class=" btn-check" autocomplete="off" name="test" id="id_test_1" value="2" '
+                "disabled required>"
                 '<label class="btn btn-outline-primary" for="id_test_1">two</label>'
-                '</div>'
+                "</div>"
                 "</div>"
             ),
         )


### PR DESCRIPTION
Fixes #111 

Also edited the `RadioSelectButtonGroup` template so that the widget can be rendered as disabled.