### PR TITLE
Fix documentation for button sizes

### DIFF
--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -552,13 +552,9 @@ def bootstrap_button(content, **kwargs):
 
             Accepts one of the following values:
 
-                * ``'xs'``
                 * ``'sm'``
-                * ``'small'``
-                * ``'md'``
-                * ``'medium'``
+                * ``'md'`` (default)
                 * ``'lg'``
-                * ``'large'``
 
         href
             Render the button as an ``<a>`` element. The ``href`` attribute is set with this value.


### PR DESCRIPTION
I'm very new to both this framework and Django however when placing a button I was given an error I did not expect.

{% bootstrap_button button_class="btn-success" size="xs" content="Start" %}

returned a ValueError Exception

`Invalid value "sx" for parameter "size" (valid values are sm, md, lg).`

I assume this exception is raised [here](https://github.com/zostera/django-bootstrap5/blob/a6fe1fe47e2e367afe1818baa780fe1464393417/src/django_bootstrap5/size.py#L16)

````
SIZE_SM = "sm"
SIZE_MD = "md"
SIZE_LG = "lg"
SIZES = [SIZE_SM, SIZE_MD, SIZE_LG]
DEFAULT_SIZE = SIZE_MD
````

If this is the case then it seems the only valid sized are sm, md, and lg.

This contradicts the documentation:

[src/django_bootstrap5/templatetags/django_bootstrap5.p 553](https://github.com/zostera/django-bootstrap5/blob/a6fe1fe47e2e367afe1818baa780fe1464393417/src/django_bootstrap5/templatetags/django_bootstrap5.py#L553)

```
            Accepts one of the following values:
                * ``'xs'``
                * ``'sm'``
                * ``'small'``
                * ``'md'``
                * ``'medium'``
                * ``'lg'``
                * ``'large'``
```

In this case `xs`, `small`, `medium` and, `large` are all invalid inputs.

Based on the [Bootstrap V5.x](https://getbootstrap.com/docs/5.2/components/buttons/#sizes) docs it looks like the only options are sm and  lg (md being default)

With all of this it looks like the inline docs should be updated as per this PR.

Thanks.







