### PR TITLE
Use ruff for linting and reformatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,12 @@ tox:
 
 .PHONY: reformat
 reformat:
-	autoflake -ir --remove-all-unused-imports ${SOURCE_FILES}
-	isort ${SOURCE_FILES}
-	-docformatter -ir --pre-summary-newline --wrap-summaries=0 --wrap-descriptions=0 ${SOURCE_FILES}
+	ruff check . --fix
 	black .
 
 .PHONY: lint
 lint:
-	flake8 ${SOURCE_FILES}
-	pydocstyle ${SOURCE_FILES}
+	ruff . --no-fix
 
 .PHONY: docs
 docs:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-NAME:= $(shell python -c 'from setuptools.config.setupcfg import read_configuration as c; print(c("setup.cfg")["metadata"]["name"])')
-VERSION:= $(shell python -c 'from setuptools.config.setupcfg import read_configuration as c; print(c("setup.cfg")["metadata"]["version"])')
-PACKAGE_DIR:= src/$(subst -,_,$(NAME))
-SOURCE_FILES:= ${PACKAGE_DIR} tests example *.py
-
 .PHONY: test
 test:
 	coverage run manage.py test
@@ -21,6 +16,7 @@ reformat:
 .PHONY: lint
 lint:
 	ruff . --no-fix
+	black . --check
 
 .PHONY: docs
 docs:
@@ -50,6 +46,7 @@ build: docs
 	python -m build .
 
 .PHONY: publish
+publish: VERSION := $(shell python -c 'from setuptools.config.setupcfg import read_configuration as c; print(c("setup.cfg")["metadata"]["version"])')
 publish: porcelain branch build
 	twine upload dist/*
 	rm -rf build dist *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,22 +17,35 @@ source = ["src", ".tox/*/site-packages"]
 show_missing = true
 skip_covered = true
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-combine_as_imports = true
-line_length = 120
-skip_glob = "*/migrations/*.py"
-known_first_party = ["django_bootstrap5"]
-known_third_party = ["django"]
-src_paths = ["*.py", "django_bootstrap5", "tests", "example"]
+[tool.ruff]
+src = ["src"]
+target-version = "py37"
+line-length = 120
+select = [
+    "D",     # pydocstyle
+    "E",     # pycodestyle
+    "F",     # flake8
+    "I",     # isort
+    "UP",    # pyupgrade
+]
+ignore = [
+    "D1",    # D1: Missing docstring error codes (because not every function and class has a docstring)
+    "D203",  # D203: 1 blank line required before class docstring (conflicts with D211 and should be disabled, see https://github.com/PyCQA/pydocstyle/pull/91)
+    "D212",  # D212: Multi-line docstring summary should start at the first line
+    "D301",  # D301: Use r”“” if any backslashes in a docstring (unclear how else to handle backslashes in docstrings)
+]
 
-[tool.pydocstyle]
-# Explanation of rules that are ignored (and why):
-# D1: Missing docstring error codes (because not every function and class has a docstring)
-# D202: No blank lines allowed after function docstring (play nice with docformatter)
-# D301: Use r”“” if any backslashes in a docstring (unclear how else to handle backslashes in docstrings)
-# D413: Missing blank line after last section (play nice with docformatter)
-add_ignore = ["D1", "D202", "D301", "D413"]
+fix = false
+fixable = [
+    "I001",  # isort (sorting)
+    "F",     # flake8
+    "D",     # docformatter
+    "UP",    # pyupgrade
+]
+unfixable = [
+    "F8",    # names in flake8, such as defined but unused variables
+]
+
+[tool.ruff.isort]
+known-first-party = ["django_bootstrap5", "app"]
+known-third-party = ["django"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,12 @@
 -r docs/requirements.txt
 django==4.2
+pillow==9.5.0
+beautifulsoup4==4.12.2
 black==23.3.0
-isort==5.12.0
-flake8==6.0.0
-pydocstyle==6.3.0
-docformatter==1.6.3
-autoflake==2.1.1
-tox==4.5.0
+ruff==0.0.262
+check-manifest==0.49
+coverage[toml]==7.2.3
+tox==4.4.12
 wheel==0.40.0
 setuptools==67.7.2
 twine==4.0.2
-pillow==9.5.0
-coverage[toml]==7.2.3
-beautifulsoup4==4.12.2
-check-manifest==0.49

--- a/tests/test_bootstrap_pagination.py
+++ b/tests/test_bootstrap_pagination.py
@@ -16,7 +16,7 @@ class PaginatorTestCase(BootstrapTestCase):
         self.assertEqual(url_replace_param("/foo/bar#id", "baz", "foo"), "/foo/bar?baz=foo#id")
 
     def bootstrap_pagination(self, page, extra=""):
-        """Helper to test bootstrap_pagination tag."""
+        """Render bootstrap_pagination tag."""
         return self.render(f"{{% bootstrap_pagination page {extra} %}}", {"page": page})
 
     def test_paginator(self):

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,9 @@ deps =
     django41: Django==4.1.*
     django42: Django==4.2.*
     djangomain: https://github.com/django/django/archive/main.tar.gz
+    coverage[toml]
     beautifulsoup4>=4.8.0
     pillow
-    coverage[toml]
-    coveralls
 
 [testenv:coverage]
 depends =
@@ -65,14 +64,12 @@ basepython = python3.9
 changedir = {toxinidir}
 skip_install = true
 deps =
-  twine
+    twine
 # In this environment, we need latest the pip, setuptools, and wheel.
 commands_pre =
-  {envpython} -m pip install -U pip setuptools wheel
+    {envpython} -m pip install -U pip setuptools wheel
 commands =
-  {envpython} -m pip wheel -w {envtmpdir}/build --no-deps .
-  twine check {envtmpdir}/build/*
-
+    make check-description
 # Runs check-manifest, a tool that builds the package and compares the
 # files in the package to the files under version control, and fails
 # if any version-controlled files do not end up in the package.
@@ -82,15 +79,6 @@ basepython = python3.9
 changedir = {toxinidir}
 skip_install = true
 deps =
-  check-manifest
+    check-manifest
 commands =
-  check-manifest --verbose
-
-[flake8]
-# flake8 does not support pyproject.toml, so we use tox.ini
-# E731 do not assign a lambda expression
-# W503 line break before binary operator (black introduces these)
-# E203 whitespace before ':'
-ignore = E731,W503,E203
-exclude = .git,.tox,__pycache__
-max-line-length = 120
+    make check-manifest


### PR DESCRIPTION
- Use `ruff`
- Add configuration for `ruff`
- Remove other linting and formatting tools except for `black`
- Remove configurations of removed tools
- Fix code style where necessary