### PR TITLE
tox.ini: enable ruff testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     py311-{4.2,5.0,5.1,main},
     py312-{4.2,5.0,5.1,main},
     docs,
-    lint,
+    ruff,
 
 [testenv]
 basepython =
@@ -31,9 +31,8 @@ deps =
 
 [testenv:ruff]
 basepython = python3.11
-allowlist_externals = ruff
 deps = ruff
-commands = ruff .
+commands = ruff check .
 
 [testenv:docs]
 basepython = python3.11


### PR DESCRIPTION
Hi!
I noticed that tox.ini contained a testenv for ruff which was not included in the envlist and thus was never run by default.

- add `ruff` environment to envlist
- remove `lint` environment from envlist, since no such environment exists (the default testenv was run instead)
- update ruff command to use `ruff check`
- remove `allowlist_externals` option: should be redundant when ruff is included in the environment's deps