### PR TITLE
Remove <nav> from pagination

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/pagination.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/pagination.html
@@ -1,38 +1,36 @@
 {% load django_bootstrap5 %}
 {% with url=bootstrap_pagination_url|default:"" %}
-    <nav>
-        <ul class="{{ pagination_css_classes }}">
-            <li class="page-item{% if current_page == 1 %} disabled{% endif %}">
+    <ul class="{{ pagination_css_classes }}">
+        <li class="page-item{% if current_page == 1 %} disabled{% endif %}">
+            <a class="page-link"
+               href="{% if current_page == 1 %}#{% else %}{% bootstrap_url_replace_param url parameter_name 1 %}{% endif %}">
+                &laquo;
+            </a>
+        </li>
+        {% if pages_back %}
+            <li class="page-item">
                 <a class="page-link"
-                   href="{% if current_page == 1 %}#{% else %}{% bootstrap_url_replace_param url parameter_name 1 %}{% endif %}">
-                    &laquo;
+                   href="{% bootstrap_url_replace_param url parameter_name pages_back %}">&hellip;</a>
+            </li>
+        {% endif %}
+        {% for page in pages_shown %}
+            <li class="page-item{% if current_page == page %} active{% endif %}">
+                <a class="page-link"
+                   href="{% if current_page == page %}#{% else %}{% bootstrap_url_replace_param url parameter_name page %}{% endif %}">
+                    {{ page }}
                 </a>
             </li>
-            {% if pages_back %}
-                <li class="page-item">
-                    <a class="page-link"
-                       href="{% bootstrap_url_replace_param url parameter_name pages_back %}">&hellip;</a>
-                </li>
-            {% endif %}
-            {% for page in pages_shown %}
-                <li class="page-item{% if current_page == page %} active{% endif %}">
-                    <a class="page-link"
-                       href="{% if current_page == page %}#{% else %}{% bootstrap_url_replace_param url parameter_name page %}{% endif %}">
-                        {{ page }}
-                    </a>
-                </li>
-            {% endfor %}
-            {% if pages_forward %}
-                <li class="page-item">
-                    <a class="page-link" href="{% bootstrap_url_replace_param url parameter_name pages_forward %}">&hellip;</a>
-                </li>
-            {% endif %}
-            <li class="page-item{% if current_page == num_pages %} disabled{% endif %}">
-                <a class="page-link"
-                   href="{% if current_page == num_pages %}#{% else %}{% bootstrap_url_replace_param url parameter_name num_pages %}{% endif %}">
-                    &raquo;
-                </a>
+        {% endfor %}
+        {% if pages_forward %}
+            <li class="page-item">
+                <a class="page-link" href="{% bootstrap_url_replace_param url parameter_name pages_forward %}">&hellip;</a>
             </li>
-        </ul>
-    </nav>
+        {% endif %}
+        <li class="page-item{% if current_page == num_pages %} disabled{% endif %}">
+            <a class="page-link"
+               href="{% if current_page == num_pages %}#{% else %}{% bootstrap_url_replace_param url parameter_name num_pages %}{% endif %}">
+                &raquo;
+            </a>
+        </li>
+    </ul>
 {% endwith %}

--- a/tests/test_bootstrap_pagination.py
+++ b/tests/test_bootstrap_pagination.py
@@ -24,14 +24,12 @@ class PaginatorTestCase(BootstrapTestCase):
         self.assertHTMLEqual(
             html,
             (
-                "<nav>"
                 '<ul class="pagination">'
                 '<li class="page-item"><a class="page-link" href="/projects/?foo=bar&page=1">&laquo;</a></li>'
                 '<li class="page-item"><a class="page-link" href="/projects/?foo=bar&page=1">1</a></li>'
                 '<li class="page-item active"><a class="page-link" href="#">2</a></li>'
                 '<li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>'
                 "</ul>"
-                "</nav>"
             ),
         )
 
@@ -51,40 +49,34 @@ class PaginatorTestCase(BootstrapTestCase):
         self.assertHTMLEqual(
             self.render('{% bootstrap_pagination page size="sm" %}', {"page": self.paginator.page(2)}),
             (
-                "<nav>"
                 '<ul class="pagination pagination-sm">'
                 '<li class="page-item"><a class="page-link" href="?page=1">&laquo;</a></li>'
                 '<li class="page-item"><a class="page-link" href="?page=1">1</a></li>'
                 '<li class="page-item active"><a class="page-link" href="#">2</a></li>'
                 '<li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>'
                 "</ul>"
-                "</nav>"
             ),
         )
         self.assertHTMLEqual(
             self.render('{% bootstrap_pagination page size="lg" %}', {"page": self.paginator.page(2)}),
             (
-                "<nav>"
                 '<ul class="pagination pagination-lg">'
                 '<li class="page-item"><a class="page-link" href="?page=1">&laquo;</a></li>'
                 '<li class="page-item"><a class="page-link" href="?page=1">1</a></li>'
                 '<li class="page-item active"><a class="page-link" href="#">2</a></li>'
                 '<li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>'
                 "</ul>"
-                "</nav>"
             ),
         )
         self.assertHTMLEqual(
             self.render('{% bootstrap_pagination page size="md" %}', {"page": self.paginator.page(2)}),
             (
-                "<nav>"
                 '<ul class="pagination">'
                 '<li class="page-item"><a class="page-link" href="?page=1">&laquo;</a></li>'
                 '<li class="page-item"><a class="page-link" href="?page=1">1</a></li>'
                 '<li class="page-item active"><a class="page-link" href="#">2</a></li>'
                 '<li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>'
                 "</ul>"
-                "</nav>"
             ),
         )
 
@@ -95,14 +87,12 @@ class PaginatorTestCase(BootstrapTestCase):
         self.assertHTMLEqual(
             self.render('{% bootstrap_pagination page justify_content="center" %}', {"page": self.paginator.page(2)}),
             (
-                "<nav>"
                 '<ul class="pagination justify-content-center">'
                 '<li class="page-item"><a class="page-link" href="?page=1">&laquo;</a></li>'
                 '<li class="page-item"><a class="page-link" href="?page=1">1</a></li>'
                 '<li class="page-item active"><a class="page-link" href="#">2</a></li>'
                 '<li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>'
                 "</ul>"
-                "</nav>"
             ),
         )
         with self.assertRaises(ValueError):


### PR DESCRIPTION
fixes #449

Providing a fixed label is not feasible because this project does not have any translations yet.

From the other two options, I guess that not having a `<nav>` element is better than having an unusable one.