### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,24 +18,18 @@ jobs:
     needs: [ ruff ]
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
         django-version: [4.2, 5.0, 5.1, "main"]
         exclude:
             # Django 5.0
-            - python-version: 3.8
-              django-version: 5.0
             - python-version: 3.9
               django-version: 5.0
 
             # Django 5.1
-            - python-version: 3.8
-              django-version: 5.1
             - python-version: 3.9
               django-version: 5.1
 
             # Django main
-            - python-version: 3.8
-              django-version: "main"
             - python-version: 3.9
               django-version: "main"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Remove `<nav>` from pagination (#686, @xi).
+- Drop support for Python 3.8 in the test matrix
 
 ## 24.3 (2024-09-17)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -31,7 +30,7 @@ keywords = ["django", "bootstrap", "bootstrap5"]
 license = {file = "LICENSE"}
 name = "django-bootstrap5"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 version = "24.3"
 
 [project.optional-dependencies]
@@ -48,7 +47,7 @@ Source = "https://github.com/zostera/django-bootstrap5"
 fix = false
 line-length = 120
 src = ["src"]
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 fixable = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 args_are_paths = false
 envlist =
-    py38-{4.2},
     py39-{4.2},
     py310-{4.2,5.0,5.1,main},
     py311-{4.2,5.0,5.1,main},
@@ -11,7 +10,6 @@ envlist =
 
 [testenv]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
EOL since 2024-10-07 (https://www.python.org/downloads/)