### PR TITLE
Field valid and invalid custom classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove `<nav>` from pagination (#686, @xi).
 - Add an `id` to the help text of fields for Django 5.0+, to match the `aria-describedby` attribute.
 - Drop support for Python 3.8 in the test matrix
+- Add field paramaters for custom valid and invalid classes
 
 ## 24.3 (2024-09-17)
 

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -246,6 +246,9 @@ class FieldRenderer(BaseRenderer):
             else success_css_class
         )
 
+        self.field_valid_class = kwargs.get("field_valid_class", "is-valid")
+        self.field_invalid_class = kwargs.get("field_invalid_class", "is-invalid")
+
     @property
     def is_floating(self):
         return (
@@ -426,9 +429,9 @@ class FieldRenderer(BaseRenderer):
     def get_server_side_validation_classes(self):
         """Return CSS classes for server-side validation."""
         if self.field_errors:
-            return "is-invalid"
+            return self.field_invalid_class
         elif self.field.form.is_bound:
-            return "is-valid"
+            return self.field_valid_class
         return ""
 
     def get_inline_field_class(self):

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -479,6 +479,16 @@ def bootstrap_field(field, **kwargs):
 
             :default: ``'has-success'``. Can be changed :doc:`settings`
 
+        field_valid_class
+            CSS class used by the field when it is valid
+
+            :default: ``'is-valid'``.
+
+        field_invalid_class
+            CSS class used by the field when it is invalid
+
+            :default: ``'is-invalid'``
+
     **Usage**::
 
         {% bootstrap_field field %}

--- a/tests/test_bootstrap_field.py
+++ b/tests/test_bootstrap_field.py
@@ -50,6 +50,23 @@ class FieldTestCase(BootstrapTestCase):
         )
         self.assertIn('class="form-control field-class-test"', html)
 
+    def test_valid_field_class(self):
+        form = SubjectTestForm({"subject": "valid_data"})
+        form.is_valid()
+        html = self.render("{% bootstrap_field form.subject field_valid_class='custom-class' %}", {"form": form})
+        self.assertNotIn('class="form-control is-valid"', html)
+        self.assertIn('class="form-control custom-class"', html)
+
+    def test_invalid_field_class(self):
+        form = SubjectTestForm({"invalid_field": "invalid_data"})
+        form.is_valid()
+        html = self.render(
+            "{% bootstrap_field form.subject field_invalid_class='custom-class' %}",
+            {"form": form},
+        )
+        self.assertNotIn('class="form-control is-invalid"', html)
+        self.assertIn('class="form-control custom-class"', html)
+
     def test_xss_field(self):
         html = self.render("{% bootstrap_field form.xss_field %}", {"form": XssTestForm()})
         self.assertIn('type="text"', html)


### PR DESCRIPTION
Adds  2 new parameters to the field renderer to allow overriding the default valid and invalid classes

Fixes #738