### PR TITLE
[fix] show invalid feedback

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
@@ -1,5 +1,6 @@
 {% if field_errors %}
     <div id="{{ field.auto_id }}_error">
+	<div class="is-invalid"></div>
         {% for text in field_errors %}
             <div class="invalid-feedback">{{ text }}</div>
         {% endfor %}

--- a/tests/test_bootstrap_field_input_checkbox.py
+++ b/tests/test_bootstrap_field_input_checkbox.py
@@ -40,6 +40,7 @@ class InputTypeCheckboxTestCase(BootstrapTestCase):
                 '<input class="form-check-input is-invalid" id="id_test" name="test" required type="checkbox">'
                 '<label class="form-check-label" for="id_test">Test</label>'
                 '<div id="id_test_error">'
+                '<div class="is-invalid"></div>'
                 '<div class="invalid-feedback">This field is required.</div>'
                 "</div>"
                 "</div>"

--- a/tests/test_bootstrap_field_input_text.py
+++ b/tests/test_bootstrap_field_input_text.py
@@ -44,6 +44,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<input type="text" name="test"'
                 ' class="form-control is-invalid" placeholder="Test" required id="id_test">'
                 '<div id="id_test_error">'
+                '<div class="is-invalid"></div>'
                 '<div class="invalid-feedback">This field is required.</div>'
                 "</div>"
                 "</div>"
@@ -202,6 +203,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<input type="text" name="test" minlength="1" class="form-control'
                 ' is-invalid" placeholder="Test" required id="id_test">'
                 '<div id="id_test_error">'
+                '<div class="is-invalid"></div>'
                 '<div class="invalid-feedback">This field is required.</div>'
                 "</div>"
                 "</div>"


### PR DESCRIPTION
resolves #763 

by adding a dummy div that triggers one of the rules in https://github.com/twbs/bootstrap/blob/main/scss/forms/_validation.scss

as there are no e2e browser tests I tested the visibility in a local project #trustmebro

in the process I had to set up a shell.nix. If there is interest in adding this to the repo, I'm happy to create another PR for this.