### PR TITLE
make sure that field errors are always visible 

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
@@ -1,7 +1,7 @@
 {% if field_errors %}
     <div id="{{ field.auto_id }}_error">
         {% for text in field_errors %}
-            <div class="invalid-feedback">{{ text }}</div>
+            <div class="invalid-feedback d-block">{{ text }}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/field_errors.html
@@ -1,5 +1,5 @@
 {% if field_errors %}
-    <div id="{{ field.auto_id }}_error">
+    <div id="{{ field.auto_id }}_error" class="w-100">
         {% for text in field_errors %}
             <div class="invalid-feedback d-block">{{ text }}</div>
         {% endfor %}

--- a/tests/test_bootstrap_field_input_checkbox.py
+++ b/tests/test_bootstrap_field_input_checkbox.py
@@ -40,7 +40,7 @@ class InputTypeCheckboxTestCase(BootstrapTestCase):
                 '<input class="form-check-input is-invalid" id="id_test" name="test" required type="checkbox">'
                 '<label class="form-check-label" for="id_test">Test</label>'
                 '<div id="id_test_error">'
-                '<div class="invalid-feedback">This field is required.</div>'
+                '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"
                 "</div>"

--- a/tests/test_bootstrap_field_input_checkbox.py
+++ b/tests/test_bootstrap_field_input_checkbox.py
@@ -39,7 +39,7 @@ class InputTypeCheckboxTestCase(BootstrapTestCase):
                 '<div class="form-check">'
                 '<input class="form-check-input is-invalid" id="id_test" name="test" required type="checkbox">'
                 '<label class="form-check-label" for="id_test">Test</label>'
-                '<div id="id_test_error">'
+                '<div id="id_test_error" class="w-100">'
                 '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"

--- a/tests/test_bootstrap_field_input_text.py
+++ b/tests/test_bootstrap_field_input_text.py
@@ -44,7 +44,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<input type="text" name="test"'
                 ' class="form-control is-invalid" placeholder="Test" required id="id_test">'
                 '<div id="id_test_error">'
-                '<div class="invalid-feedback">This field is required.</div>'
+                '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"
             ),
@@ -202,7 +202,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<input type="text" name="test" minlength="1" class="form-control'
                 ' is-invalid" placeholder="Test" required id="id_test">'
                 '<div id="id_test_error">'
-                '<div class="invalid-feedback">This field is required.</div>'
+                '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"
                 "</div>"

--- a/tests/test_bootstrap_field_input_text.py
+++ b/tests/test_bootstrap_field_input_text.py
@@ -43,7 +43,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<label class="form-label" for="id_test">Test</label>'
                 '<input type="text" name="test"'
                 ' class="form-control is-invalid" placeholder="Test" required id="id_test">'
-                '<div id="id_test_error">'
+                '<div id="id_test_error" class="w-100">'
                 '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"
@@ -201,7 +201,7 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 '<span class="input-group-text">foo</span>'
                 '<input type="text" name="test" minlength="1" class="form-control'
                 ' is-invalid" placeholder="Test" required id="id_test">'
-                '<div id="id_test_error">'
+                '<div id="id_test_error" class="w-100">'
                 '<div class="invalid-feedback d-block">This field is required.</div>'
                 "</div>"
                 "</div>"


### PR DESCRIPTION
Fixes #763 and potentially #749

I also fixed the `.input-group` related issue I mentioned in https://github.com/zostera/django-bootstrap5/issues/763#issuecomment-3249350281.

I implemented this as an alternative to #766 because I thought that just overwriting bootstrap's `display: none` is more robust than adding dummy elements.