### PR TITLE
Fix HTML escaping for checkboxes with empty labels

### DIFF
--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -388,7 +388,7 @@ class FieldRenderer(BaseRenderer):
                 label_for=label_for,
                 label_class=self.get_label_class(horizontal=horizontal),
             )
-        return label_html
+        return mark_safe(label_html)
 
     def get_help_html(self):
         """Return HTML for help text."""


### PR DESCRIPTION
## Summary
Fixes HTML escaping issue when checkboxes have empty labels.

## Problem
When a checkbox field has an empty label, the HTML was being escaped during rendering due to SafeText being lost during string concatenation in the render method.

## Solution
Ensure `get_label_html()` always returns SafeText by wrapping the return value with `mark_safe()`, preventing loss of safe designation during concatenation. I believe this is OK because when `label_html` is non-empty it hits the if statement.