### PR TITLE
Fix placeholder being set on color and range inputs

### DIFF
--- a/src/django_bootstrap5/widgets.py
+++ b/src/django_bootstrap5/widgets.py
@@ -15,4 +15,6 @@ class RadioSelectButtonGroup(RadioSelect):
 
 def is_widget_with_placeholder(widget):
     """Return whether this widget can have a placeholder."""
+    if isinstance(widget, TextInput):
+        return widget.input_type not in ("color", "range")
     return isinstance(widget, (TextInput, Textarea, NumberInput, EmailInput, URLInput, PasswordInput))

--- a/tests/test_bootstrap_field_input_color.py
+++ b/tests/test_bootstrap_field_input_color.py
@@ -16,7 +16,7 @@ class InputTypeColorTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label for="id_test" class="form-label">Test</label>'
                 '<input class="form-control form-control-color" '
-                'id="id_test" name="test" placeholder="Test" required type="color">'
+                'id="id_test" name="test" required type="color">'
                 "</div>"
             ),
         )
@@ -30,7 +30,7 @@ class InputTypeColorTestCase(BootstrapTestCase):
                 '<label for="id_test" class="col-form-label col-sm-2">Test</label>'
                 '<div class="col-sm-10">'
                 '<input class="form-control form-control-color" id="id_test"'
-                ' name="test" placeholder="Test" required type="color">'
+                ' name="test" required type="color">'
                 "</div>"
                 "</div>"
             ),
@@ -44,7 +44,7 @@ class InputTypeColorTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label for="id_test" class="form-label">Test</label>'
                 '<input class="form-control form-control-color" id="id_test"'
-                ' name="test" placeholder="Test" required type="color">'
+                ' name="test" required type="color">'
                 "</div>"
             ),
         )

--- a/tests/test_bootstrap_field_input_range.py
+++ b/tests/test_bootstrap_field_input_range.py
@@ -15,7 +15,7 @@ class InputTypeRangeTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label for="id_test" class="form-label">Test</label>'
-                '<input class="form-range" id="id_test" name="test" placeholder="Test" required type="range">'
+                '<input class="form-range" id="id_test" name="test" required type="range">'
                 "</div>"
             ),
         )
@@ -28,7 +28,7 @@ class InputTypeRangeTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req row mb-3">'
                 '<label for="id_test" class="col-form-label col-sm-2">Test</label>'
                 '<div class="col-sm-10">'
-                '<input class="form-range" id="id_test" name="test" placeholder="Test" required type="range">'
+                '<input class="form-range" id="id_test" name="test" required type="range">'
                 "</div>"
                 "</div>"
             ),
@@ -41,7 +41,7 @@ class InputTypeRangeTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label for="id_test" class="form-label">Test</label>'
-                '<input class="form-range" id="id_test" name="test" placeholder="Test" required type="range">'
+                '<input class="form-range" id="id_test" name="test" required type="range">'
                 "</div>"
             ),
         )


### PR DESCRIPTION
## Summary

- `is_widget_with_placeholder()` was returning `True` for `TextInput` instances with `input_type` of `"color"` or `"range"`
- This caused a `placeholder` attribute to be rendered on those inputs — browsers ignore it per the HTML5 spec
- Fix checks `widget.input_type` (not `widget.attrs.get("type")` — Django moves `type` out of `attrs` into `input_type` at construction time)

## Test plan

- [x] Updated `test_bootstrap_field_input_color.py` — removed `placeholder` from expected HTML (3 layout variants)
- [x] Updated `test_bootstrap_field_input_range.py` — removed `placeholder` from expected HTML (3 layout variants)
- [x] Full test suite passes (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)