### PR TITLE
Add regression tests for is-valid/is-invalid on range inputs

### DIFF
--- a/tests/test_bootstrap_field_input_range.py
+++ b/tests/test_bootstrap_field_input_range.py
@@ -45,3 +45,17 @@ class InputTypeRangeTestCase(BootstrapTestCase):
                 "</div>"
             ),
         )
+
+    def test_input_type_range_invalid(self):
+        """Test that range input gets is-invalid class when bound with errors."""
+        form = RangeTestForm(data={})
+        html = self.render("{% bootstrap_field form.test %}", context={"form": form})
+        self.assertIn("is-invalid", html)
+        self.assertNotIn("is-valid", html)
+
+    def test_input_type_range_valid(self):
+        """Test that range input gets is-valid class when bound and valid."""
+        form = RangeTestForm(data={"test": "5"})
+        html = self.render("{% bootstrap_field form.test %}", context={"form": form})
+        self.assertIn("is-valid", html)
+        self.assertNotIn("is-invalid", html)


### PR DESCRIPTION
## Summary

- Range inputs correctly receive `is-valid`/`is-invalid` validation classes (Bootstrap 5 supports this)
- No test existed to guard against regressions — add two focused tests using `assertIn` to verify the classes are present/absent on bound valid and invalid forms

## Test plan

- [x] `test_input_type_range_invalid` — bound form with empty data → `is-invalid` present, `is-valid` absent
- [x] `test_input_type_range_valid` — bound form with valid data → `is-valid` present, `is-invalid` absent
- [x] Full test suite passes (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)