### PR TITLE
Add "input_class" argument to bootstrap_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
 - Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).
 - Fix placeholder being set on color and range inputs (#832).
 - Fix bugs in `url_replace_param`, jinja2 helpers, and `BaseRenderer.render`; add AGENTS.md (#830).

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -254,6 +254,8 @@ class FieldRenderer(BaseRenderer):
             else success_css_class
         )
 
+        self.input_class = kwargs.get("input_class", "")
+
     @property
     def is_floating(self):
         return (
@@ -310,7 +312,7 @@ class FieldRenderer(BaseRenderer):
         size_prefix = None
 
         before = []
-        classes = [widget.attrs.get("class", ""), text_value(self.field_class)]
+        classes = [widget.attrs.get("class", ""), text_value(self.field_class), text_value(self.input_class)]
 
         if ReadOnlyPasswordHashWidget is not None and isinstance(widget, ReadOnlyPasswordHashWidget):
             before.append("form-control-plaintext")

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -472,6 +472,11 @@ def bootstrap_field(field, **kwargs):
 
             :default: ``'has-success'``. Can be changed :doc:`settings`
 
+        input_class
+            CSS class added to the input html element
+
+            :default: ``''``
+
     **Usage**::
 
         {% bootstrap_field field %}

--- a/tests/test_bootstrap_field.py
+++ b/tests/test_bootstrap_field.py
@@ -84,6 +84,12 @@ class FieldTestCase(BootstrapTestCase):
         _test_size_medium("md")
         _test_size_medium("")
 
+    def test_input_class(self):
+        self.assertIn(
+            'class="form-control foobar-class"',
+            self.render('{% bootstrap_field form.subject input_class="foobar-class" %}', {"form": SubjectTestForm()}),
+        )
+
     def test_label(self):
         self.assertEqual(
             self.render('{% bootstrap_label "foobar" label_for="subject" %}'),


### PR DESCRIPTION
## Summary
Rebases #535 (originally by @frolenkov-nikita, closes #525) onto current `main`. The original PR had gone stale since Nov 2023 and conflicted with `renderers.py` (which since gained `field_class` handling in the same code path).

- Cherry-picked the original commit, author preserved.
- Resolved conflicts in `CHANGELOG.md` and `renderers.py` — `input_class` is now combined with `field_class` in `add_widget_class_attrs`, both wrapped in `text_value()` for consistency.
- No other functional changes.

## Test plan
- [x] `just test` — 140 passed, including the original `test_input_class` test
- [x] `just lint` — all checks passed

Closes #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)