### PR TITLE
Update default Bootstrap CDN URLs to 5.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update default Bootstrap to 5.3.8.
 - Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
 - Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).
 - Fix placeholder being set on color and range inputs (#832).

--- a/src/django_bootstrap5/core.py
+++ b/src/django_bootstrap5/core.py
@@ -4,13 +4,13 @@ from django.conf import settings
 
 BOOTSTRAP5_DEFAULTS = {
     "css_url": {
-        "url": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css",
-        "integrity": "sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH",
+        "url": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css",
+        "integrity": "sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB",
         "crossorigin": "anonymous",
     },
     "javascript_url": {
-        "url": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js",
-        "integrity": "sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz",
+        "url": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js",
+        "integrity": "sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI",
         "crossorigin": "anonymous",
     },
     "theme_url": None,


### PR DESCRIPTION
## Summary
Upstream Bootstrap's latest release is 5.3.8 (published 2025-08-26); this repo's default CDN URLs were still pinned to 5.3.3. Release notes for the intervening patches are CSS/WCAG fixes and dependency bumps, no breaking changes.

- Bumped `css_url` and `javascript_url` defaults in `core.py` to 5.3.8.
- Recomputed SRI `integrity` hashes (sha384) from the jsdelivr-hosted files for both assets.

## Test plan
- [x] `just test` — 140 passed
- [x] `just lint` — all checks passed
- [x] Verified downloaded CSS/JS file sizes are sane before hashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)