### PR TITLE
Add layout setting for default form/field layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).
 - Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
 - Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).
 - Fix placeholder being set on color and range inputs (#832).

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -9,7 +9,7 @@ They can be modified by adding a dict variable called ``BOOTSTRAP5`` in your ``s
 The ``BOOTSTRAP5`` dict variable contains these settings and defaults:
 
 
-.. code:: django
+.. code:: python
 
     # Default settings
     BOOTSTRAP5 = {
@@ -39,6 +39,10 @@ The ``BOOTSTRAP5`` dict variable contains these settings and defaults:
 
         # Put JavaScript in the HEAD section of the HTML document (only relevant if you use bootstrap5.html).
         'javascript_in_head': False,
+
+        # Default layout class
+        # Can be floating, horizontal, or inline
+        'default_layout': '',
 
         # Wrapper class for non-inline fields.
         # The default value "mb-3" is the spacing as used by Bootstrap 5 example code.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -40,9 +40,9 @@ The ``BOOTSTRAP5`` dict variable contains these settings and defaults:
         # Put JavaScript in the HEAD section of the HTML document (only relevant if you use bootstrap5.html).
         'javascript_in_head': False,
 
-        # Default layout class
-        # Can be floating, horizontal, or inline
-        'default_layout': '',
+        # Default layout for forms and fields.
+        # Can be floating, horizontal, or inline. Can be overridden per call with the "layout" argument.
+        'layout': '',
 
         # Wrapper class for non-inline fields.
         # The default value "mb-3" is the spacing as used by Bootstrap 5 example code.

--- a/src/django_bootstrap5/core.py
+++ b/src/django_bootstrap5/core.py
@@ -16,6 +16,7 @@ BOOTSTRAP5_DEFAULTS = {
     "theme_url": None,
     "color_mode": None,
     "javascript_in_head": False,
+    "default_layout": "",
     "wrapper_class": "mb-3",
     "inline_wrapper_class": "",
     "horizontal_label_class": "col-sm-2",

--- a/src/django_bootstrap5/core.py
+++ b/src/django_bootstrap5/core.py
@@ -16,7 +16,7 @@ BOOTSTRAP5_DEFAULTS = {
     "theme_url": None,
     "color_mode": None,
     "javascript_in_head": False,
-    "default_layout": "",
+    "layout": "",
     "wrapper_class": "mb-3",
     "inline_wrapper_class": "",
     "horizontal_label_class": "col-sm-2",

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -34,7 +34,7 @@ class BaseRenderer:
     form_errors_template = "django_bootstrap5/form_errors.html"
 
     def __init__(self, **kwargs):
-        self.layout = kwargs.get("layout", "")
+        self.layout = kwargs.get("layout", get_bootstrap_setting("default_layout"))
         self.wrapper_class = kwargs.get("wrapper_class", get_bootstrap_setting("wrapper_class"))
         self.inline_wrapper_class = kwargs.get("inline_wrapper_class", get_bootstrap_setting("inline_wrapper_class"))
         self.field_class = kwargs.get("field_class", "")

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -34,7 +34,7 @@ class BaseRenderer:
     form_errors_template = "django_bootstrap5/form_errors.html"
 
     def __init__(self, **kwargs):
-        self.layout = kwargs.get("layout", get_bootstrap_setting("default_layout"))
+        self.layout = kwargs.get("layout", get_bootstrap_setting("layout"))
         self.wrapper_class = kwargs.get("wrapper_class", get_bootstrap_setting("wrapper_class"))
         self.inline_wrapper_class = kwargs.get("inline_wrapper_class", get_bootstrap_setting("inline_wrapper_class"))
         self.field_class = kwargs.get("field_class", "")

--- a/tests/test_bootstrap_form.py
+++ b/tests/test_bootstrap_form.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from django import forms
 from django.forms import formset_factory
+from django.test import override_settings
 
 from tests.base import DJANGO_VERSION, BootstrapTestCase
 
@@ -208,5 +209,79 @@ class HorizontalFormTestCase(BootstrapTestCase):
                 '<label class="form-check-label" for="id_test">Test</label>'
                 "</div>"
                 "</div>"
+            ),
+        )
+
+
+class DefaultLayoutTestCase(BootstrapTestCase):
+    @override_settings(
+        BOOTSTRAP5={
+            "default_layout": "horizontal",
+        },
+    )
+    def test_horizontal_default_layout(self):
+        form = ShowLabelTestForm()
+        html = self.render(
+            "{% bootstrap_form form %}",
+            context={"form": form},
+        )
+        self.assertHTMLEqual(
+            html,
+            (
+                '<div class="mb-3 row">'
+                '<label class="col-form-label col-sm-2" for="id_subject">'
+                'Subject'
+                '</label>'
+                '<div class="col-sm-10">'
+                '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
+                '</div>'
+                '</div>'
+            ),
+        )
+
+    @override_settings(
+        BOOTSTRAP5={
+            "default_layout": "inline",
+            "inline_wrapper_class": "custom-inline-wrapper-class",
+        },
+    )
+    def test_inline_default_layout(self):
+        form = ShowLabelTestForm()
+        html = self.render(
+            "{% bootstrap_form form %}",
+            context={"form": form},
+        )
+        self.assertHTMLEqual(
+            html,
+            (
+                '<div class="col-12 custom-inline-wrapper-class">'
+                '<label class="visually-hidden" for="id_subject">'
+                'Subject'
+                '</label>'
+                '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
+                "</div>"
+            ),
+        )
+
+    @override_settings(
+        BOOTSTRAP5={
+            "default_layout": "floating",
+        },
+    )
+    def test_floating_default_layout(self):
+        form = ShowLabelTestForm()
+        html = self.render(
+            "{% bootstrap_form form %}",
+            context={"form": form},
+        )
+        self.assertHTMLEqual(
+            html,
+            (
+                '<div class="form-floating mb-3">'
+                '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
+                '<label class="form-label" for="id_subject">'
+                'Subject'
+                '</label>'
+                '</div>'
             ),
         )

--- a/tests/test_bootstrap_form.py
+++ b/tests/test_bootstrap_form.py
@@ -216,7 +216,7 @@ class HorizontalFormTestCase(BootstrapTestCase):
 class DefaultLayoutTestCase(BootstrapTestCase):
     @override_settings(
         BOOTSTRAP5={
-            "default_layout": "horizontal",
+            "layout": "horizontal",
         },
     )
     def test_horizontal_default_layout(self):
@@ -230,18 +230,18 @@ class DefaultLayoutTestCase(BootstrapTestCase):
             (
                 '<div class="mb-3 row">'
                 '<label class="col-form-label col-sm-2" for="id_subject">'
-                'Subject'
-                '</label>'
+                "Subject"
+                "</label>"
                 '<div class="col-sm-10">'
                 '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
-                '</div>'
-                '</div>'
+                "</div>"
+                "</div>"
             ),
         )
 
     @override_settings(
         BOOTSTRAP5={
-            "default_layout": "inline",
+            "layout": "inline",
             "inline_wrapper_class": "custom-inline-wrapper-class",
         },
     )
@@ -256,8 +256,8 @@ class DefaultLayoutTestCase(BootstrapTestCase):
             (
                 '<div class="col-12 custom-inline-wrapper-class">'
                 '<label class="visually-hidden" for="id_subject">'
-                'Subject'
-                '</label>'
+                "Subject"
+                "</label>"
                 '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
                 "</div>"
             ),
@@ -265,7 +265,7 @@ class DefaultLayoutTestCase(BootstrapTestCase):
 
     @override_settings(
         BOOTSTRAP5={
-            "default_layout": "floating",
+            "layout": "floating",
         },
     )
     def test_floating_default_layout(self):
@@ -280,8 +280,8 @@ class DefaultLayoutTestCase(BootstrapTestCase):
                 '<div class="form-floating mb-3">'
                 '<input class="form-control" id="id_subject" name="subject" placeholder="Subject" required type="text">'
                 '<label class="form-label" for="id_subject">'
-                'Subject'
-                '</label>'
-                '</div>'
+                "Subject"
+                "</label>"
+                "</div>"
             ),
         )


### PR DESCRIPTION
## Summary
Rebases #531 (originally by @blag, closes #190) onto current `main`.

- Cherry-picked the two real commits from #531 (skipped merge commits), authorship preserved.
- Renamed the new setting from `default_layout` to `layout`. Every other `BOOTSTRAP5` setting mirrors its kwarg name exactly (`wrapper_class`, `field_class`, `checkbox_layout`, `server_side_validation`, ...) — the setting *is* the default, that's already conveyed by doc comments, not a name prefix. `default_layout` was the only setting in the dict breaking that pattern; since it hadn't shipped yet, no back-compat cost to fixing it before merge.
- Verified interaction with the new floating+addon warning (#833): `is_floating`/the warning check both key off `self.layout`, which is populated the same way whether it comes from the per-call kwarg or the settings default — no special-casing needed.
- Reformatted the cherry-picked test file to satisfy `ruff format` (quote style only).

## Test plan
- [x] `just test` — 143 passed (140 existing + 3 new layout tests: horizontal/inline/floating)
- [x] `just lint` — all checks passed

Closes #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)