### PR TITLE
Stop hardcoding Bootstrap version in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ AGENTS.md is **not** synced — each package has its own.
 
 ## Bootstrap 5
 
-Current stable release is 5.3. New Bootstrap releases are expected — update support when they arrive.
+The default CDN URLs in `src/django_bootstrap5/core.py` are pinned to a specific Bootstrap release. Check https://github.com/twbs/bootstrap/releases for newer ones — don't hardcode a version number here, it will drift.
 
-Docs: https://getbootstrap.com/docs/5.3/
+Docs: https://getbootstrap.com/docs/5.3/ (versioned by major.minor; update this link when adopting a new minor)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
AGENTS.md claimed "Current stable release is 5.3" — a factual statement with nothing forcing it to update, so it silently went stale (actual pinned CDN version had already drifted to 5.3.3, then 5.3.8, while this line still said "5.3").

README already handles the analogous Python/Django case correctly — it defers to the upstream source ("See Supported Versions on djangoproject.com") instead of stating a number. This applies the same pattern to Bootstrap: point at the actual source of truth (`core.py`'s pinned URL, and upstream's releases page) instead of restating a number here.

## Test plan
- [x] `just lint` — all checks passed
- N/A for tests (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)