### PR TITLE
Drop support for Django 4.2 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.2", "6.0", "main"]
+        django-version: ["5.2", "6.0", "main"]
         exclude:
-          # Django 4.2
-          - python-version: "3.14"
-            django-version: "4.2"
           # Django 6.0
           - python-version: "3.10"
             django-version: "6.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,10 +109,10 @@ Test matrix (tox) — not a full grid:
 
 | Python  | Django versions         |
 |---------|-------------------------|
-| 3.10    | 4.2, 5.2                |
-| 3.11    | 4.2, 5.2                |
-| 3.12    | 4.2, 5.2, 6.0, main     |
-| 3.13    | 4.2, 5.2, 6.0, main     |
+| 3.10    | 5.2                     |
+| 3.11    | 5.2                     |
+| 3.12    | 5.2, 6.0, main          |
+| 3.13    | 5.2, 6.0, main          |
 | 3.14    | 5.2, 6.0, main          |
 
 Target the matrix when adding features; avoid Django-version-specific code paths where possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Drop support for Django 4.2 (EOL).
 - Update default Bootstrap to 5.3.8.
 - Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
 - Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
@@ -24,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Topic :: Utilities",
 ]
-dependencies = ["Django>=4.2"]
+dependencies = ["Django>=5.2"]
 description = "Bootstrap 5 for Django"
 keywords = ["django", "bootstrap", "bootstrap5"]
 license = "BSD-3-Clause"

--- a/tests/test_bootstrap_field.py
+++ b/tests/test_bootstrap_field.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .base import DJANGO_VERSION, BootstrapTestCase
+from .base import BootstrapTestCase
 
 
 class XssTestForm(forms.Form):
@@ -24,19 +24,17 @@ class FieldTestCase(BootstrapTestCase):
     def test_show_help(self):
         html = self.render("{% bootstrap_field form.subject %}", {"form": SubjectTestForm()})
         self.assertIn("my_help_text", html)
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            self.assertIn('aria-describedby="id_subject_helptext"', html)
-            self.assertIn('<div id="id_subject_helptext" class="form-text">my_help_text</div>', html)
+        self.assertIn('aria-describedby="id_subject_helptext"', html)
+        self.assertIn('<div id="id_subject_helptext" class="form-text">my_help_text</div>', html)
         self.assertNotIn("<i>my_help_text</i>", html)
         html = self.render("{% bootstrap_field form.subject show_help=False %}", {"form": SubjectTestForm()})
         self.assertNotIn("my_help_text", html)
 
     def test_help_text_overridden_aria_describedby(self):
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            form = SubjectTestForm()
-            form.fields["subject"].widget.attrs["aria-describedby"] = "my_id"
-            html = self.render("{% bootstrap_field form.subject %}", {"form": form})
-            self.assertIn('<div id="id_subject_helptext" class="form-text">my_help_text</div>', html)
+        form = SubjectTestForm()
+        form.fields["subject"].widget.attrs["aria-describedby"] = "my_id"
+        html = self.render("{% bootstrap_field form.subject %}", {"form": form})
+        self.assertIn('<div id="id_subject_helptext" class="form-text">my_help_text</div>', html)
 
     def test_placeholder(self):
         html = self.render("{% bootstrap_field form.subject %}", {"form": SubjectTestForm()})

--- a/tests/test_bootstrap_field_input_checkbox.py
+++ b/tests/test_bootstrap_field_input_checkbox.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from tests.base import DJANGO_VERSION, BootstrapTestCase
+from tests.base import BootstrapTestCase
 
 
 class CheckboxTestForm(forms.Form):
@@ -28,10 +28,8 @@ class InputTypeCheckboxTestCase(BootstrapTestCase):
             "{% bootstrap_field form.test %}",
             context={"form": CheckboxTestForm(data={})},
         )
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            html = html.replace(' aria-invalid="true"', "")
-        if DJANGO_VERSION >= "5.2":  # TODO: Django 5.1
-            html = html.replace(' aria-describedby="id_test_error"', "")
+        html = html.replace(' aria-invalid="true"', "")
+        html = html.replace(' aria-describedby="id_test_error"', "")
         self.assertHTMLEqual(
             html,
             (

--- a/tests/test_bootstrap_field_input_text.py
+++ b/tests/test_bootstrap_field_input_text.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms import TextInput
 
-from tests.base import DJANGO_VERSION, BootstrapTestCase
+from tests.base import BootstrapTestCase
 
 
 class CharFieldTestForm(forms.Form):
@@ -31,10 +31,8 @@ class InputTypeTextTestCase(BootstrapTestCase):
 
         form = CharFieldTestForm(data={})
         html = self.render("{% bootstrap_field form.test %}", context={"form": form})
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            html = html.replace(' aria-invalid="true"', "")
-        if DJANGO_VERSION >= "5.2":  # TODO: Django 5.1
-            html = html.replace(' aria-describedby="id_test_error"', "")
+        html = html.replace(' aria-invalid="true"', "")
+        html = html.replace(' aria-describedby="id_test_error"', "")
 
         self.assertHTMLEqual(
             html,
@@ -187,10 +185,8 @@ class InputTypeTextTestCase(BootstrapTestCase):
         self.assertFalse(form.is_valid())
 
         html = self.render('{% bootstrap_field form.test addon_before="foo" %}', context={"form": form})
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            html = html.replace(' aria-invalid="true"', "")
-        if DJANGO_VERSION >= "5.2":  # TODO: Django 5.1
-            html = html.replace(' aria-describedby="id_test_error"', "")
+        html = html.replace(' aria-invalid="true"', "")
+        html = html.replace(' aria-describedby="id_test_error"', "")
 
         self.assertHTMLEqual(
             html,

--- a/tests/test_bootstrap_form.py
+++ b/tests/test_bootstrap_form.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 from django import forms
 from django.forms import formset_factory
 
-from tests.base import DJANGO_VERSION, BootstrapTestCase
+from tests.base import BootstrapTestCase
 
 
 class FormTestForm(forms.Form):
@@ -36,8 +36,7 @@ class BootstrapFormTestCase(BootstrapTestCase):
             '{% bootstrap_form form exclude="optional_text" %}',
             {"form": FormTestForm()},
         )
-        if DJANGO_VERSION >= "5":  # TODO: Django 4.2
-            html = html.replace(' aria-describedby="id_required_text_helptext"', "")
+        html = html.replace(' aria-describedby="id_required_text_helptext"', "")
         self.assertHTMLEqual(
             html,
             (

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ requires =
     tox>=4.2
 args_are_paths = false
 envlist =
-    py310-{4.2,5.2},
-    py311-{4.2,5.2},
-    py312-{4.2,5.2,6.0,main},
-    py313-{4.2,5.2,6.0,main},
+    py310-{5.2},
+    py311-{5.2},
+    py312-{5.2,6.0,main},
+    py313-{5.2,6.0,main},
     py314-{5.2,6.0,main},
 
 [testenv]
@@ -22,7 +22,6 @@ extras =
 dependency_groups =
     test
 deps =
-    4.2: Django==4.2.*
     5.2: Django==5.2.*
     6.0: Django==6.0.*
     main: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
## Summary
Django 4.2 LTS reached end of life on 2026-04-07 (per endoflife.date). Dropping it and bumping the floor to 5.2, the next supported LTS — matches the pattern of prior "Drop support for Django X.Y (EOL)" changes in the CHANGELOG.

- `pyproject.toml` — drop the `Framework :: Django :: 4.2` classifier, bump `Django>=4.2` → `>=5.2`
- `tox.ini` / `ci.yml` — drop 4.2 from the test matrix and the now-dead 3.14/4.2 exclude rule
- `AGENTS.md` — update the matrix table
- Checked for 4.2-specific code paths and linter/tool settings tied to the old floor: found none in `src/` (no C-extension-specific or version-gated production code), no models/migrations in the test app, no Django-version-tied ruff/lint config. The only 4.2-specific logic was in tests (see below).
- `tests/` — four files had `if DJANGO_VERSION >= "5":` / `>= "5.2":` branches bridging 4.2-vs-5.x rendering differences (`aria-invalid`, `aria-describedby`, help-text markup). These are always true now that 4.2 is the dropped floor, so inlined them and removed the now-dead branch + unused `DJANGO_VERSION` imports. Left the unrelated `DJANGO_VERSION < "6.0"` checks in `test_bootstrap_field_datetime.py` alone — those bridge 5.x-vs-6.0 behavior, still relevant.

## Test plan
- [x] `just test` — 140 passed (Django 5.2.15)
- [x] `just lint` — all checks passed
- [x] `just tests` (full tox matrix, all 11 remaining Python × Django combos) — all green, including confirming `main` now resolves to Django 6.2.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)