### PR TITLE
Add MAINTAINING.md; scope + PR checklist in CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ AGENTS.md is **not** synced — each package has its own.
 
 ## Bootstrap 5
 
-The default CDN URLs in `src/django_bootstrap5/core.py` are pinned to a specific Bootstrap release. Check https://github.com/twbs/bootstrap/releases for newer ones — don't hardcode a version number here, it will drift.
+The default CDN URLs in `src/django_bootstrap5/core.py` are pinned to a specific Bootstrap release. Check https://github.com/twbs/bootstrap/releases for newer ones — don't hardcode a version number here, it will drift. See [MAINTAINING.md](MAINTAINING.md) for the full version-support policy (Python, Django, and Bootstrap).
 
 Docs: https://getbootstrap.com/docs/5.3/ (versioned by major.minor; update this link when adopting a new minor)
 
@@ -105,15 +105,7 @@ tests/
 
 The tox matrix includes a `jinja` extra for Jinja2 integration testing.
 
-Test matrix (tox) — not a full grid:
-
-| Python  | Django versions         |
-|---------|-------------------------|
-| 3.10    | 5.2                     |
-| 3.11    | 5.2                     |
-| 3.12    | 5.2, 6.0, main          |
-| 3.13    | 5.2, 6.0, main          |
-| 3.14    | 5.2, 6.0, main          |
+The current Python × Django matrix is not a full grid — see `tox.ini`'s `envlist` for what's actually tested (`pyproject.toml` classifiers and `ci.yml`'s matrix must match it). Don't copy the matrix into prose elsewhere; it drifts. See [MAINTAINING.md](MAINTAINING.md) for the policy behind how the matrix is chosen and kept current.
 
 Target the matrix when adding features; avoid Django-version-specific code paths where possible.
 
@@ -125,11 +117,4 @@ GitHub Actions runs on every push and PR:
 
 `just lint` must pass before committing — CI enforces it and will fail the PR.
 
-## Release process
-
-1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
-2. Commit and push to `main`
-3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
-4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
-
-`just release-tag` requires: clean working directory AND current branch is `main`. It will fail otherwise.
+See [MAINTAINING.md](MAINTAINING.md) for the release process and version-support policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Drop support for Django 4.2 (EOL).
 - Update default Bootstrap to 5.3.8.
 - Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ You can contribute in many ways:
 
 The goal of this project is to seamlessly blend Django and Bootstrap 5: template tags and
 widgets that render Bootstrap 5 markup for Django forms. Contributions that fit that goal are
-welcome. Contributions that don't — a competing form-rendering abstraction, support for other
-CSS frameworks, functionality unrelated to rendering Django forms as Bootstrap 5 — are likely
-to be closed even if well-implemented, so it's worth opening an issue to discuss scope before
-investing time in a pull request.
+welcome. Contributions that don't (such as a competing form-rendering abstraction, support for
+other CSS frameworks, functionality unrelated to rendering Django forms as Bootstrap 5) are
+likely to be closed even if well-implemented, so it's worth opening an issue to discuss scope
+before investing time in a pull request.
 
 ## Types of Contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,15 @@ little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
+## Scope
+
+The goal of this project is to seamlessly blend Django and Bootstrap 5: template tags and
+widgets that render Bootstrap 5 markup for Django forms. Contributions that fit that goal are
+welcome. Contributions that don't — a competing form-rendering abstraction, support for other
+CSS frameworks, functionality unrelated to rendering Django forms as Bootstrap 5 — are likely
+to be closed even if well-implemented, so it's worth opening an issue to discuss scope before
+investing time in a pull request.
+
 ## Types of Contributions
 
 ### Report Bugs
@@ -19,11 +28,11 @@ If you are reporting a bug, please include:
 
 ### Fix Bugs
 
-Look through the GitHub issues for bugs. Anything tagged with \"bug\" is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to whoever wants to implement it.
 
 ### Implement Features
 
-Look through the GitHub issues for features. Anything tagged with \"feature\" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with "feature" is open to whoever wants to implement it.
 
 ### Write Documentation
 
@@ -41,7 +50,7 @@ If you are proposing a feature:
 
 ## Get Started!
 
-Ready to contribute? Here\'s how to set up `django-bootstrap5` for local development.
+Ready to contribute? Here's how to set up `django-bootstrap5` for local development.
 
 You will need some knowledge of git, github, and Python/Django development. Using a Python virtual environment is advised.
 
@@ -75,5 +84,16 @@ just tests
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests for new or changed functionality, and pass all tests.
-2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in CHANGELOG.md.
+1. It fits the project's [scope](#scope) — if in doubt, open an issue first.
+2. It includes tests for new or changed functionality, and passes all existing tests (`just test`).
+3. It doesn't change the rendered markup or DOM structure of an existing widget or tag unless
+   that's the explicit point of the PR — existing users depend on the current output.
+4. New settings or `{% bootstrap_* %}` keyword arguments follow existing naming conventions —
+   in particular, a setting shares its name with the kwarg it defaults (e.g. `wrapper_class`
+   is both the kwarg and the `BOOTSTRAP5` setting key), not a `default_`-prefixed variant.
+5. It doesn't add a new runtime dependency without discussing it in an issue first.
+6. If it adds functionality, the docs are updated and the change is added to `CHANGELOG.md`.
+
+Pull requests that don't meet these may be asked for changes, or closed if they've gone stale
+without a response — see [MAINTAINING.md](MAINTAINING.md) for how the project handles review
+backlog and version support.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,46 @@
+# Maintaining django-bootstrap5
+
+Notes for maintainers. For how to submit a contribution, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Version support policy
+
+These are rules, not a snapshot of current versions — the current matrix lives in `tox.ini`
+(`envlist`), `.github/workflows/ci.yml` (the `python_django_matrix` job), and `pyproject.toml`
+(classifiers + `dependencies`). Those three files are the source of truth and must agree with
+each other. Don't restate the matrix as a table in prose docs (AGENTS.md, README, etc.) — a
+copy always drifts out of sync with the files that actually enforce it.
+
+### Python and Django
+
+- Support every Python and Django release cycle that is not end-of-life, per
+  [endoflife.date/python](https://endoflife.date/python) and
+  [endoflife.date/django](https://endoflife.date/django). Drop a cycle from the matrix as soon
+  as it goes EOL — don't wait for a scheduled release to do it.
+- Always track Django's `main` branch in the matrix. Add a new Django release series
+  (e.g. 6.1) alongside `main` as soon as `main` has diverged from it — i.e. once upstream
+  cuts a `stable/X.Y.x` branch and `main` itself moves on to the next alpha. Don't wait for
+  the new series' final release.
+- Add a new Python pre-release as a **non-blocking** CI job (`continue-on-error: true`) as
+  soon as it's installable — `uv python install` can usually fetch a new CPython the same day
+  it's cut, so the interpreter itself is rarely the blocker. Only make the job blocking once
+  our C-extension test dependencies (currently Pillow) publish wheels for it; that's normally
+  the actual bottleneck.
+
+### Bootstrap
+
+- Keep the default CDN URLs in `src/django_bootstrap5/core.py` pinned to the latest Bootstrap
+  5.3.x patch release. Check [github.com/twbs/bootstrap/releases](https://github.com/twbs/bootstrap/releases)
+  for newer ones.
+- When bumping it, update the URL and the SRI `integrity` hash together, and verify the hash
+  against the actual downloaded file — don't copy one from memory or from an unrelated source.
+- Don't hardcode a Bootstrap version number in prose docs. Point at `core.py` and the upstream
+  releases page instead.
+
+## Release process
+
+1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
+2. Commit and push to `main`
+3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
+4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+
+`just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.


### PR DESCRIPTION
## Summary
Splits durable maintenance policy from the actually-current version matrix, and gives contributors an explicit scope statement + review checklist up front.

- **New `MAINTAINING.md`** — version-support policy as rules, not a version snapshot: support every non-EOL Python/Django cycle per endoflife.date, add a new Django series alongside `main` as soon as `main` diverges (not waiting for the final release), add Python pre-releases as non-blocking CI jobs until Pillow ships wheels for them, keep Bootstrap CDN URLs on the latest 5.3.x patch. States that `tox.ini`/`ci.yml`/`pyproject.toml` are the sole source of truth for the actual matrix — nothing else should restate it. Also moved "Release process" here from AGENTS.md (was duplicated in two maintainer-facing docs).
- **`AGENTS.md`** — replaced the hardcoded Python×Django matrix table (already flagged as a drift risk) with a pointer to `tox.ini`; replaced the Release process section with a pointer to MAINTAINING.md.
- **`CONTRIBUTING.md`** — added a `## Scope` section (what fits the project vs. what's likely to get closed regardless of implementation quality) and expanded the PR guidelines into a checklist covering scope fit, DOM/markup stability, naming conventions (setting name mirrors its kwarg, no `default_` prefix), and no new deps without discussion. Also fixed stray escaped-quote artifacts (`\"`, `\'`) left over in the file's prose.

## Test plan
- [x] `just lint` — all checks passed
- [x] `just docs` — builds successfully (2 harmless myst-parser warnings for cross-doc links Sphinx doesn't index — both links resolve fine on GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)