### PR TITLE
Add ability to specify the form attribute for radio input

### DIFF
--- a/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
@@ -12,6 +12,7 @@
                        id="{{ option.attrs.id }}"
                         {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"
                             {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}
+                        {% if widget.attrs.form %} form="{{ widget.attrs.form }}"{% endif %}
                         {% if widget.attrs.disabled or option.attrs.disabled %} disabled{% endif %}>
                 <label class="form-check-label" for="{{ option.attrs.id }}">{{ option.label }}</label>
             </div>

--- a/tests/test_bootstrap_field_radio_select.py
+++ b/tests/test_bootstrap_field_radio_select.py
@@ -24,6 +24,16 @@ class DisabledSelectTestForm(forms.Form):
     )
 
 
+class SelectOtherTestForm(forms.Form):
+    test = forms.ChoiceField(
+        choices=(
+            (1, "one"),
+            (2, "two"),
+        ),
+        widget=forms.RadioSelect(attrs={"form": "another-form"}),
+    )
+
+
 class RadioSelectWithDisabledOptions(forms.RadioSelect):
     def __init__(self, attrs=None, choices=(), *, disabled_values=()):
         super().__init__(attrs)
@@ -149,6 +159,27 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 "</div>"
                 '<div class="form-check">'
                 '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2">'
+                '<label class="form-check-label" for="id_test_1">two</label>'
+                "</div>"
+                "</div>"
+                "</div>"
+            ),
+        )
+
+    def test_other_form_select(self):
+        """Test field with select that belongs to another form widget."""
+        self.assertHTMLEqual(
+            self.render("{% bootstrap_field form.test %}", context={"form": SelectOtherTestForm()}),
+            (
+                '<div class="django_bootstrap5-req mb-3">'
+                '<label class="form-label">Test</label>'
+                '<div class="" form="another-form" required id="id_test">'
+                '<div class="form-check">'
+                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_0" value="1">'
+                '<label class="form-check-label" for="id_test_0">one</label>'
+                "</div>"
+                '<div class="form-check">'
+                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_1" value="2">'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"


### PR DESCRIPTION
## Summary
Rebases #304 (originally by @paulchubatyy) onto current `main`. Despite already carrying an APPROVED review, the original PR had three real bugs — none of them caught because the test file didn't actually run as committed:

- Template: `` {% if widget.attrs.form %} form="{{ widget.attrs.form }}{% endif %}`` was missing the closing `"` on the attribute value — malformed HTML. Fixed.
- Test: `SelectOtherTestForm`'s field definition was missing the closing `)` on `forms.ChoiceField(...)` — a syntax error, meaning this file could not have been imported as committed. Fixed.
- Test: the new test asserted against `context={"form": DisabledSelectTestForm()}` instead of the `SelectOtherTestForm` it defines — so even once the syntax error was fixed, it wasn't testing the new behavior at all. Fixed to use the right form, and updated the expected HTML to match what actually renders (including `form="another-form"` also appearing on the wrapper `<div>` — consistent with this widget's existing behavior where `disabled`/`required` also leak onto the wrapper via `{% include "django/forms/widgets/attrs.html" %}`, already covered by `test_disabled_select`).

## Test plan
- [x] `just test` — 144 passed (140 existing + 4 new: `test_other_form_select` plus this branch picks up the layout/6.1 changes already on `main`)
- [x] `just lint` — all checks passed

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)