### PR TITLE
Add label_class setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `label_class` setting so a default label CSS class can be set globally (#260).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Add support for Django 6.1.
 - Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -52,6 +52,9 @@ The ``BOOTSTRAP5`` dict variable contains these settings and defaults:
         # The default value is empty, as Bootstrap5 example code doesn't use a wrapper class.
         'inline_wrapper_class': '',
 
+        # CSS class for the label element.
+        'label_class': '',
+
         # Field class for inline fields.
         # the default value is "col-12". This class will combined with `inline_wrapper_class`.
         'inline_field_class': 'col-auto',

--- a/src/django_bootstrap5/core.py
+++ b/src/django_bootstrap5/core.py
@@ -19,6 +19,7 @@ BOOTSTRAP5_DEFAULTS = {
     "layout": "",
     "wrapper_class": "mb-3",
     "inline_wrapper_class": "",
+    "label_class": "",
     "horizontal_label_class": "col-sm-2",
     "horizontal_field_class": "col-sm-10",
     "horizontal_field_offset_class": "offset-sm-2",

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -38,7 +38,7 @@ class BaseRenderer:
         self.wrapper_class = kwargs.get("wrapper_class", get_bootstrap_setting("wrapper_class"))
         self.inline_wrapper_class = kwargs.get("inline_wrapper_class", get_bootstrap_setting("inline_wrapper_class"))
         self.field_class = kwargs.get("field_class", "")
-        self.label_class = kwargs.get("label_class", "")
+        self.label_class = kwargs.get("label_class", get_bootstrap_setting("label_class"))
         self.show_help = kwargs.get("show_help", True)
         self.show_label = kwargs.get("show_label", True)
         self.exclude = kwargs.get("exclude", "")

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -382,6 +382,8 @@ def bootstrap_field(field, **kwargs):
         label_class
             CSS class of the ``label`` element. Will always have ``control-label`` as the last CSS class.
 
+            :default: ``''``. Can be changed :doc:`settings`
+
         show_help
             Show the field's help text, if the field has help text.
 

--- a/tests/test_bootstrap_field.py
+++ b/tests/test_bootstrap_field.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.test import override_settings
 
 from .base import BootstrapTestCase
 
@@ -93,3 +94,16 @@ class FieldTestCase(BootstrapTestCase):
             self.render('{% bootstrap_label "foobar" label_for="subject" %}'),
             '<label class="form-label" for="subject">foobar</label>',
         )
+
+    @override_settings(BOOTSTRAP5={"label_class": "custom-label-class"})
+    def test_label_class_setting(self):
+        html = self.render("{% bootstrap_field form.subject %}", {"form": SubjectTestForm()})
+        self.assertIn('class="form-label custom-label-class"', html)
+
+    def test_label_class_kwarg_overrides_setting(self):
+        with override_settings(BOOTSTRAP5={"label_class": "custom-label-class"}):
+            html = self.render(
+                '{% bootstrap_field form.subject label_class="kwarg-label-class" %}', {"form": SubjectTestForm()}
+            )
+            self.assertIn('class="form-label kwarg-label-class"', html)
+            self.assertNotIn("custom-label-class", html)


### PR DESCRIPTION
## Summary
Fixes #260. Every other per-field CSS class kwarg has a `BOOTSTRAP5` setting fallback (`wrapper_class`, `horizontal_label_class`, `horizontal_field_class`, `inline_field_class`, ...) except `label_class`, which could only be set per-`{% bootstrap_field %}`-call — no way to set a project-wide default.

- Added `"label_class": ""` to `BOOTSTRAP5_DEFAULTS` in `core.py`.
- `FieldRenderer.__init__` now falls back to `get_bootstrap_setting("label_class")` instead of a hardcoded `""`.
- Documented it in the `bootstrap_field` docstring and `docs/settings.rst`.

## Test plan
- [x] `just test` — 146 passed (2 new tests: setting applies, per-call kwarg still overrides it)
- [x] `just lint` — all checks passed
- [x] Manually reverted the source change and confirmed `test_label_class_setting` fails as expected (the kwarg-override test correctly still passes either way, since that path already worked)

Fixes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)