### PR TITLE
Recognize month and datetime-local widget subclasses as form-control widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Add support for Django 6.1.
 - Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -289,6 +289,8 @@ class FieldRenderer(BaseRenderer):
                 "date",
                 "time",
                 "password",
+                "month",
+                "datetime-local",
             ]
 
         return isinstance(widget, Textarea)

--- a/tests/test_bootstrap_field_input_text.py
+++ b/tests/test_bootstrap_field_input_text.py
@@ -335,3 +335,53 @@ class InputTypeTextTestCase(BootstrapTestCase):
                 "</div>"
             ),
         )
+
+
+class MonthInput(forms.DateInput):
+    input_type = "month"
+
+
+class DateTimeLocalInput(forms.DateTimeInput):
+    input_type = "datetime-local"
+
+
+class MonthTestForm(forms.Form):
+    test = forms.DateField(widget=MonthInput)
+
+
+class DateTimeLocalTestForm(forms.Form):
+    test = forms.DateTimeField(widget=DateTimeLocalInput)
+
+
+class CustomInputTypeTestCase(BootstrapTestCase):
+    """Test widget subclasses with an input_type not built into Django (#309, #678)."""
+
+    def test_month_gets_addon_support(self):
+        html = self.render(
+            '{% bootstrap_field form.test addon_before="foo" %}',
+            context={"form": MonthTestForm()},
+        )
+        self.assertIn('<span class="input-group-text">foo</span>', html)
+        self.assertIn('type="month"', html)
+
+    def test_month_gets_floating_label(self):
+        html = self.render(
+            "{% bootstrap_field form.test layout='floating' %}",
+            context={"form": MonthTestForm()},
+        )
+        self.assertIn("form-floating", html)
+
+    def test_datetime_local_gets_addon_support(self):
+        html = self.render(
+            '{% bootstrap_field form.test addon_before="foo" %}',
+            context={"form": DateTimeLocalTestForm()},
+        )
+        self.assertIn('<span class="input-group-text">foo</span>', html)
+        self.assertIn('type="datetime-local"', html)
+
+    def test_datetime_local_gets_floating_label(self):
+        html = self.render(
+            "{% bootstrap_field form.test layout='floating' %}",
+            context={"form": DateTimeLocalTestForm()},
+        )
+        self.assertIn("form-floating", html)


### PR DESCRIPTION
## Summary
Fixes #309, #678. Django ships no built-in `MonthInput`/`DateTimeLocalInput` widgets for these HTML5 input types — the standard recipe is subclassing `DateInput`/`DateTimeInput` and overriding `input_type`. `is_form_control_widget()`'s whitelist didn't include `"month"`/`"datetime-local"`, so such widgets silently missed out on addon support and floating labels (`can_widget_float` delegates to the same check).

Note on #740 ("date-local"): that's not a real HTML5 input type (valid ones are `date`, `time`, `month`, `week`, `datetime-local`) — the breakage they saw is a browser/spec issue, not something this package can fix by adding it to an allowlist. Left a comment pointing them at `datetime-local` instead of adding it here.

## Test plan
- [x] `just test` — 148 passed (4 new: month/datetime-local get addon support and floating labels)
- [x] `just lint` — all checks passed
- [x] Manually reverted the source change and confirmed all 4 new tests fail as expected

Fixes #309, #678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)