### PR TITLE
Support addon_before/addon_after on Select widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support `addon_before`/`addon_after` on `Select` widgets, excluding `SelectMultiple` and `RadioSelect` (#613).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Add support for Django 6.1.
 - Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -305,6 +305,13 @@ class FieldRenderer(BaseRenderer):
             return self.size == DEFAULT_SIZE and not isinstance(widget, (SelectMultiple, RadioSelect))
         return False
 
+    def can_widget_have_addons(self, widget=None):
+        """Return whether given widget can be rendered with addon_before/addon_after."""
+        widget = widget or self.widget
+        if self.is_form_control_widget(widget):
+            return True
+        return isinstance(widget, Select) and not isinstance(widget, (SelectMultiple, RadioSelect))
+
     def add_widget_class_attrs(self, widget=None):
         """Add class attribute to widget."""
         if widget is None:
@@ -507,7 +514,7 @@ class FieldRenderer(BaseRenderer):
         help = self.get_help_html()
         errors = self.get_errors_html()
 
-        if self.is_form_control_widget():
+        if self.can_widget_have_addons():
             if self.addon_before_class is None:
                 addon_before = self.addon_before
             else:

--- a/tests/test_bootstrap_field_select.py
+++ b/tests/test_bootstrap_field_select.py
@@ -45,6 +45,41 @@ class BootstrapFieldRadioSelectTestCase(BootstrapTestCase):
             ),
         )
 
+    def test_select_addons(self):
+        """Test field with select widget and addon_before/addon_after (#613)."""
+        self.assertHTMLEqual(
+            self.render(
+                '{% bootstrap_field form.test addon_before="foo" addon_after="bar" %}',
+                context={"form": SelectTestForm()},
+            ),
+            (
+                '<div class="django_bootstrap5-req mb-3">'
+                '<label for="id_test" class="form-label">Test</label>'
+                '<div class="input-group">'
+                '<span class="input-group-text">foo</span>'
+                '<select class="form-select" id="id_test" name="test">'
+                '<option value="1">one</option>'
+                '<option value="2">two</option>'
+                "</select>"
+                '<span class="input-group-text">bar</span>'
+                "</div>"
+                "</div>"
+            ),
+        )
+
+    def test_select_multiple_no_addons(self):
+        """SelectMultiple should not get addons — an input-group with a multi-select doesn't make sense."""
+
+        class SelectMultipleTestForm(forms.Form):
+            test = forms.MultipleChoiceField(choices=((1, "one"), (2, "two")))
+
+        html = self.render(
+            '{% bootstrap_field form.test addon_before="foo" %}',
+            context={"form": SelectMultipleTestForm()},
+        )
+        self.assertNotIn("input-group", html)
+        self.assertNotIn("foo", html)
+
     def test_select_floating(self):
         """Test field with select widget in floating layout."""
         self.assertHTMLEqual(


### PR DESCRIPTION
## Summary
Fixes #613. Addon rendering was gated on `is_form_control_widget()`, which only recognizes `Input`/`Textarea` subclasses — `Select` widgets got no addon support at all, with no way to opt in.

Added a separate `can_widget_have_addons()` check rather than folding `Select` into `is_form_control_widget()` directly. `is_form_control_widget()` also backs `can_widget_float()`, which has its own size-restricted `Select` handling (`self.size == DEFAULT_SIZE`) — folding `Select` support in at the shared method would have silently let non-default-size selects start floating too, an unrelated behavior change. Kept the two concerns separate.

`SelectMultiple` and `RadioSelect` stay excluded, matching the same exclusions `can_widget_float` already uses for `Select` — an input-group wrapper around a multi-select or radio group doesn't make sense.

## Test plan
- [x] `just test` — 146 passed (2 new: `Select` gets addons, `SelectMultiple` doesn't)
- [x] `just lint` — all checks passed
- [x] Manually reverted the source change and confirmed the new addon test fails as expected
- [x] Confirmed existing floating-label `Select` tests (including size-restriction behavior) still pass unaffected

Fixes #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)