### PR TITLE
Rewrite radio_select.html attrs handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
 - Support `addon_before`/`addon_after` on `Select` widgets, excluding `SelectMultiple` and `RadioSelect` (#613).
 - Fix `server_side_validation` not propagating from `bootstrap_form`/`bootstrap_formset` to field renderers (#612).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.

--- a/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
+++ b/src/django_bootstrap5/templates/django_bootstrap5/widgets/radio_select.html
@@ -1,6 +1,6 @@
 {% load django_bootstrap5 %}
 {% bootstrap_server_side_validation_class widget as server_side_validation_class %}
-<div{% include "django/forms/widgets/attrs.html" %}>
+<div{% if widget.attrs.id %} id="{{ widget.attrs.id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>
     {% for group, options, index in widget.optgroups %}
         {% if group %}
             <div>{{ group }}</div>{% endif %}
@@ -9,11 +9,8 @@
                 <input class="{% bootstrap_classes 'form-check-input' server_side_validation_class %}"
                        type="{{ option.type }}"
                        name="{{ option.name }}"
-                       id="{{ option.attrs.id }}"
-                        {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"
-                            {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}
-                        {% if widget.attrs.form %} form="{{ widget.attrs.form }}"{% endif %}
-                        {% if widget.attrs.disabled or option.attrs.disabled %} disabled{% endif %}>
+                        {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% endif %}
+                        {% for attr_name, attr_value in option.attrs.items %}{% if attr_name != "class" and attr_value is not False %} {{ attr_name }}{% if attr_value is not True %}="{{ attr_value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}>
                 <label class="form-check-label" for="{{ option.attrs.id }}">{{ option.label }}</label>
             </div>
         {% endfor %}

--- a/tests/test_bootstrap_field_checkbox_select_multiple.py
+++ b/tests/test_bootstrap_field_checkbox_select_multiple.py
@@ -1,0 +1,50 @@
+from django import forms
+
+from .base import BootstrapTestCase
+
+
+class CheckboxSelectMultipleWithAttrs(forms.CheckboxSelectMultiple):
+    """Widget that adds a custom attribute to each option (#300)."""
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+        option["attrs"]["data-total"] = "5220"
+        return option
+
+
+class CheckboxSelectMultipleTestForm(forms.Form):
+    test = forms.MultipleChoiceField(
+        choices=(
+            (1, "one"),
+            (2, "two"),
+        ),
+        widget=CheckboxSelectMultipleWithAttrs,
+        required=False,
+    )
+
+
+class BootstrapFieldCheckboxSelectMultipleTestCase(BootstrapTestCase):
+    def test_custom_option_attrs_preserved(self):
+        """Custom attrs added in create_option() must survive rendering (#300)."""
+        html = self.render("{% bootstrap_field form.test %}", context={"form": CheckboxSelectMultipleTestForm()})
+        self.assertIn('data-total="5220"', html)
+        self.assertHTMLEqual(
+            html,
+            (
+                '<div class="mb-3">'
+                '<label class="form-label">Test</label>'
+                '<div id="id_test">'
+                '<div class="form-check">'
+                '<input class="form-check-input" type="checkbox" name="test" id="id_test_0" value="1"'
+                ' data-total="5220">'
+                '<label class="form-check-label" for="id_test_0">one</label>'
+                "</div>"
+                '<div class="form-check">'
+                '<input class="form-check-input" type="checkbox" name="test" id="id_test_1" value="2"'
+                ' data-total="5220">'
+                '<label class="form-check-label" for="id_test_1">two</label>'
+                "</div>"
+                "</div>"
+                "</div>"
+            ),
+        )

--- a/tests/test_bootstrap_field_radio_select.py
+++ b/tests/test_bootstrap_field_radio_select.py
@@ -65,13 +65,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
-                '<div class="" required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1" required>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2" required>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"
@@ -87,13 +87,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
                 '<div class="django_bootstrap5-req row mb-3">'
                 '<label class="col-sm-2 col-form-label">Test</label>'
                 '<div class="col-sm-10">'
-                '<div class="" required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1" required>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2" required>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"
@@ -109,13 +109,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
-                '<div class="" required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1" required>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2" required>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"
@@ -131,13 +131,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
-                '<div class="" disabled required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" disabled type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1" required disabled>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" disabled type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2" required disabled>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"
@@ -152,13 +152,13 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
-                '<div class="" required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" disabled type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_0" value="1" required disabled>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" type="radio" name="test" id="id_test_1" value="2" required>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"
@@ -173,13 +173,15 @@ class BootstrapFieldSelectTestCase(BootstrapTestCase):
             (
                 '<div class="django_bootstrap5-req mb-3">'
                 '<label class="form-label">Test</label>'
-                '<div class="" form="another-form" required id="id_test">'
+                '<div id="id_test">'
                 '<div class="form-check">'
-                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_0" value="1">'
+                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_0"'
+                ' value="1" required>'
                 '<label class="form-check-label" for="id_test_0">one</label>'
                 "</div>"
                 '<div class="form-check">'
-                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_1" value="2">'
+                '<input class="form-check-input" form="another-form" type="radio" name="test" id="id_test_1"'
+                ' value="2" required>'
                 '<label class="form-check-label" for="id_test_1">two</label>'
                 "</div>"
                 "</div>"


### PR DESCRIPTION
## Summary
Fixes #300 and #806 — two symptoms of the same root cause in `radio_select.html` (used by both `RadioSelect` and `CheckboxSelectMultiple`):

1. **#300**: each `<input>` was manually reconstructed from a hardcoded attribute whitelist (`value`, `checked`, `form`, `disabled`), so any custom attr set via a `create_option()` override (e.g. `option['attrs']['data-total'] = ...`) was silently dropped. Plain Django rendering preserves it fine; this template didn't.
2. **#806**: the wrapper `<div>` included Django's generic `attrs.html`, which dumps every widget-level attr onto it — but the wrapper isn't a form-control element, so `disabled`/`required`/`form` (and an always-present empty `class=""`) leaked onto it despite being meaningless/invalid there.

## Fix
- Wrapper `<div>` now renders only `id`/`class` explicitly — same pattern `radio_select_button_group.html` already uses.
- Each `<input>` now forwards its own `option.attrs` generically (everything: `id`, `checked`, `disabled`, `required`, `form`, custom attrs), excluding only `class` (still rendered via `bootstrap_classes` to combine with server-side-validation classes — Django's `option_inherits_attrs` already merges widget-level attrs into each option, so this matches Django's own stock widget rendering).

**Behavior change worth flagging explicitly**: individual radio/checkbox inputs now correctly get `required`/`disabled` — previously *only* the wrapper div had them, which was itself the bug (Django's own default `RadioSelect` template puts these on each input). #845's ad-hoc `{% if widget.attrs.form %}` line is also now redundant and removed, since `option.attrs` already includes it generically — no future custom attr will need its own hardcoded template line again.

## Test plan
- [x] `just test` — 148 passed. Updated every existing `RadioSelect` assertion to match the corrected output; added a new test file for `CheckboxSelectMultiple` (had zero prior coverage) covering the #300 scenario exactly.
- [x] `just lint` — all checks passed
- [x] Manually reverted the template and confirmed the new `CheckboxSelectMultiple` test and `test_disabled_select` both fail cleanly without the fix

Fixes #300, #806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)