### PR TITLE
Fix size docstrings to match actual accepted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `size` docstrings for `bootstrap_field`/`bootstrap_form` and `bootstrap_pagination` — the documented values (`'small'`/`'medium'`/`'large'`) don't exist; the accepted values are `'sm'`/`'md'`/`'lg'` (#777).
 - Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
 - Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
 - Add `label_class` setting so a default label CSS class can be set globally (#260).

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -406,9 +406,9 @@ def bootstrap_field(field, **kwargs):
 
             One of the following values:
 
-                * ``'small'``
-                * ``'medium'``
-                * ``'large'``
+                * ``'sm'``
+                * ``'md'``
+                * ``'lg'``
 
         placeholder
             Sets the placeholder text of a textbox
@@ -694,8 +694,8 @@ def bootstrap_pagination(page, **kwargs):
 
             One of the following:
 
-                * ``'small'``
-                * ``'large'``
+                * ``'sm'``
+                * ``'lg'``
 
             :default: ``None``
 


### PR DESCRIPTION
## Summary
Fixes #777. \`parse_size()\` (\`size.py\`) only accepts \`sm\`/\`md\`/\`lg\` — passing \`'small'\`/\`'medium'\`/\`'large'\` (what the \`bootstrap_field\`/\`bootstrap_form\` and \`bootstrap_pagination\` docstrings said) raises \`ValueError\`. Just correcting the docs to match the actual API.

## Test plan
- [x] \`just test\` — 154 passed (docs-only change, no behavior affected)
- [x] \`just lint\` — all checks passed

Fixes #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)