### PR TITLE
Add label kwarg to bootstrap_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `label` argument to `bootstrap_field` to override a field's label text without touching the form definition — works with horizontal/floating layout and as the default placeholder (#635).
 - Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
 - Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
 - Add `label_class` setting so a default label CSS class can be set globally (#260).

--- a/src/django_bootstrap5/renderers.py
+++ b/src/django_bootstrap5/renderers.py
@@ -214,6 +214,7 @@ class FieldRenderer(BaseRenderer):
         self.initial_attrs = self.widget.attrs.copy()
         self.help_text = text_value(field.help_text) if self.show_help and field.help_text else ""
         self.field_errors = [conditional_escape(text_value(error)) for error in field.errors]
+        self.label = kwargs.get("label", field.label)
 
         self.placeholder = text_value(kwargs.get("placeholder", self.default_placeholder))
 
@@ -269,7 +270,7 @@ class FieldRenderer(BaseRenderer):
     @property
     def default_placeholder(self):
         """Return default placeholder for field."""
-        return self.field.label if get_bootstrap_setting("set_placeholder") else ""
+        return self.label if get_bootstrap_setting("set_placeholder") else ""
 
     def restore_widget_attrs(self):
         self.widget.attrs = self.initial_attrs.copy()
@@ -410,7 +411,7 @@ class FieldRenderer(BaseRenderer):
 
         label_for = self.field.id_for_label
         return render_label(
-            self.field.label,
+            self.label,
             label_for=label_for,
             label_class=self.get_label_class(horizontal=horizontal),
         )

--- a/src/django_bootstrap5/templatetags/django_bootstrap5.py
+++ b/src/django_bootstrap5/templatetags/django_bootstrap5.py
@@ -379,6 +379,11 @@ def bootstrap_field(field, **kwargs):
         field_class
             CSS class of the ``div`` that wraps the field.
 
+        label
+            Override the field's label text. Also used as the default placeholder, if ``set_placeholder`` is on.
+
+            :default: the field's own ``label``
+
         label_class
             CSS class of the ``label`` element. Will always have ``control-label`` as the last CSS class.
 

--- a/tests/test_bootstrap_field.py
+++ b/tests/test_bootstrap_field.py
@@ -95,6 +95,19 @@ class FieldTestCase(BootstrapTestCase):
             '<label class="form-label" for="subject">foobar</label>',
         )
 
+    def test_label_kwarg(self):
+        """bootstrap_field label kwarg overrides the field's own label text (#635)."""
+        html = self.render('{% bootstrap_field form.subject label="Custom Label" %}', {"form": SubjectTestForm()})
+        self.assertIn('<label class="form-label" for="id_subject">Custom Label</label>', html)
+        self.assertNotIn(">Subject<", html)
+
+    def test_label_kwarg_used_as_default_placeholder(self):
+        class PlainTestForm(forms.Form):
+            plain = forms.CharField()
+
+        html = self.render('{% bootstrap_field form.plain label="Custom Label" %}', {"form": PlainTestForm()})
+        self.assertIn('placeholder="Custom Label"', html)
+
     @override_settings(BOOTSTRAP5={"label_class": "custom-label-class"})
     def test_label_class_setting(self):
         html = self.render("{% bootstrap_field form.subject %}", {"form": SubjectTestForm()})


### PR DESCRIPTION
## Summary
Fixes #635. There was no way to override a field's label text from the template — only by changing the Django form/field definition. The reporter's workaround (`bootstrap_label` directly) doesn't produce horizontal/floating layout markup, since that's computed inside `FieldRenderer`, not `bootstrap_label`.

- Added `self.label = kwargs.get("label", field.label)` to `FieldRenderer.__init__`, used by `get_label_html()` instead of `self.field.label` directly.
- `default_placeholder` now also uses `self.label` instead of `self.field.label` — consistent with existing behavior where the auto-placeholder already defaults to the label text, so overriding one updates the other unless `placeholder` is set explicitly too.
- Verified manually that horizontal layout (`layout='horizontal'`) correctly uses the overridden label with the right `col-form-label` classes — the part of #635 that motivated trying `bootstrap_label` as a workaround in the first place.

## Test plan
- [x] `just test` — 156 passed (2 new: label override applies, and feeds the default placeholder)
- [x] `just lint` — all checks passed
- [x] Manually reverted the source change and confirmed both new tests fail as expected
- [x] Manually confirmed the override works correctly with `layout='horizontal'`

Fixes #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)