### PR TITLE
Add typos spell checking to just lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
+- Add `typos` spell checking to `just lint`.
+- Fix typos in `CHANGELOG.md` and `docs/settings.rst`.
 - Add `label` argument to `bootstrap_field` to override a field's label text without touching the form definition — works with horizontal/floating layout and as the default placeholder (#635).
 - Fix `size` docstrings for `bootstrap_field`/`bootstrap_form` and `bootstrap_pagination` — the documented values (`'small'`/`'medium'`/`'large'`) don't exist; the accepted values are `'sm'`/`'md'`/`'lg'` (#777).
 - Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
@@ -204,7 +206,7 @@
 
 ## 0.3.0 (2021-04-18)
 
-- Fix suport for `Textarea` widgets.
+- Fix support for `Textarea` widgets.
 - Add support for horizontal forms.
 - Add support for `checkbox_type="switch"`.
 - Set PyPI Development Status to 4 - Beta.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -65,7 +65,7 @@ The ``BOOTSTRAP5`` dict variable contains these settings and defaults:
         # Field class to use in horizontal forms.
         'horizontal_field_class': 'col-sm-10',
 
-        # Field class used for horizontal fields withut a label.
+        # Field class used for horizontal fields without a label.
         'horizontal_field_offset_class': 'offset-sm-2',
 
         # HTML attributes with any of these prefixes will have underscores converted to hyphens.

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ install:
 @lint:
     uvx ruff format --check
     uvx ruff check
+    uvx typos
 
 # Run test with coverage
 @test-cov *ARGS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,7 @@ source-include = [
 
 [tool.check-manifest]
 ignore = ["uv.lock", "pyproject.toml.orig"]
+
+[tool.typos.default]
+# Subresource Integrity hashes are base64; they mint words that look like typos.
+extend-ignore-re = ['sha\d+-[A-Za-z0-9+/=]{40,}']


### PR DESCRIPTION
## Summary

Adds `uvx typos` as a third step in `just lint`, following the existing zero-install `uvx` pattern used by ruff. CI picks it up for free — `ci.yml` already runs `just lint`, and the matrix, docs, and build jobs gate on `needs: [lint]`.

Propagated from **django-marina** ([zostera/django-marina#669](https://github.com/zostera/django-marina/pull/669)), the canonical source for shared tooling per `PACKAGING.md`. Both the `justfile` line and `[tool.typos.default]` are copied verbatim — the config takes no per-package substitution.

**Why `typos` and not `codespell`, and not both.** Both do the same job, so running both means two allowlists to maintain and false positives triaged twice for no extra signal. `typos` respects `.gitignore`; codespell does not, and in this repo family it reports dozens of findings from vendored docs build assets under gitignored build directories, needing a hand-maintained `--skip` list that rots as build layout changes.

**SRI hash exclusion.** `[tool.typos.default] extend-ignore-re` skips Subresource Integrity hashes, whose base64 produces letter runs the checker reads as misspellings. A pattern is used rather than `extend-words` entries — those bless a word globally to silence one hash, and need re-editing on every CDN version bump.

## Test plan

- [x] `just lint` passes on this branch
- [x] Regex verified against all five repos before propagating, no regressions
- [x] Two real typos fixed: `suport` -> `support` in `CHANGELOG.md:206`, `withut` -> `without` in `docs/settings.rst:68`
- [x] SRI hash false positive in `docs/settings.rst:30` silenced by the pattern

The `CHANGELOG.md` fix is in a released-version entry. The wording stays accurate — a plain spelling error, not a rewrite of what shipped.

Note: `docs/changelog.md` is a symlink to `../CHANGELOG.md`. `typos` follows it and dedupes; codespell reported the same finding twice.