### PR TITLE
Fix just build: ignore transient pyproject.toml.orig in check-manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `label` argument to `bootstrap_field` to override a field's label text without touching the form definition — works with horizontal/floating layout and as the default placeholder (#635).
 - Fix `size` docstrings for `bootstrap_field`/`bootstrap_form` and `bootstrap_pagination` — the documented values (`'small'`/`'medium'`/`'large'`) don't exist; the accepted values are `'sm'`/`'md'`/`'lg'` (#777).
 - Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,4 +126,4 @@ source-include = [
 ]
 
 [tool.check-manifest]
-ignore = ["uv.lock"]
+ignore = ["uv.lock", "pyproject.toml.orig"]


### PR DESCRIPTION
## Summary

`just build` fails on `main` at the `check-manifest` step:

```
lists of files in version control and sdist do not match!
missing from VCS:
  pyproject.toml.orig
```

`check-manifest` rewrites `pyproject.toml` during its run and leaves a `pyproject.toml.orig` backup. That transient file gets swept into the sdist it builds, then flagged as missing from version control. It is removed before the command exits, so the working tree looks clean afterwards and the failure is not obvious from `git status`.

This is a propagation miss, not a new bug. Three of the five Zostera Django packages already carry the entry:

| repo | `[tool.check-manifest] ignore` | `just build` on main |
|---|---|---|
| django-marina | `["uv.lock", "pyproject.toml.orig"]` | pass |
| django-bootstrap3 | `["uv.lock", "pyproject.toml.orig"]` | pass |
| django-bootstrap4 | `["uv.lock", "pyproject.toml.orig"]` | pass |
| django-bootstrap5 | `["uv.lock"]` | **fail** |
| django-icons | `["uv.lock"]` | **fail** |

Pre-existing on `main` and unrelated to the in-flight typos PR in this repo — verified by reproducing on `main` with that branch absent.

## Test plan

- [x] `uvx check-manifest` fails on `main` with the error above
- [x] `just build` passes end to end on this branch (build, twine, check-manifest, pyroma 10/10, check-wheel-contents, both smoke tests)

## Note

Companion PR in the sibling repo with the identical one-line fix. Both this and the open typos PR touch `pyproject.toml` near the end of the file; whichever merges second may need a trivial rebase.