### PR TITLE
Add tests for django.contrib.gis form field rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add tests for `django.contrib.gis` form field rendering.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `typos` spell checking to `just lint`.
 - Fix typos in `CHANGELOG.md` and `docs/settings.rst`.

--- a/tests/test_bootstrap_field_gis.py
+++ b/tests/test_bootstrap_field_gis.py
@@ -1,0 +1,30 @@
+from django.contrib.gis import forms as gisforms
+
+from tests.base import BootstrapTestCase
+
+
+class GisTestForm(gisforms.Form):
+    point = gisforms.PointField()
+
+
+# A geometry widget builds its own template context from `attrs`. Django ticket #28105
+# was a crash in that path, triggered by a template pack passing an attr whose name the
+# widget already used. These tests guard that seam.
+class GisFieldTestCase(BootstrapTestCase):
+    """Test rendering of `django.contrib.gis` form fields."""
+
+    def test_gis_point(self):
+        """Test field with a GIS point widget."""
+        html = self.render("{% bootstrap_field form.point %}", context={"form": GisTestForm()})
+        self.assertInHTML('<label class="form-label" for="id_point">Point</label>', html)
+        # The geometry widget renders its own map markup; the serialized value is a
+        # hidden textarea that keeps the widget's own classes rather than form-control.
+        self.assertIn('id="id_point_div_map"', html)
+        self.assertIn('class="vSerializedField required"', html)
+        self.assertNotIn("form-control", html)
+
+    def test_gis_point_horizontal(self):
+        """Test field with a GIS point widget in horizontal layout."""
+        html = self.render('{% bootstrap_field form.point layout="horizontal" %}', context={"form": GisTestForm()})
+        self.assertInHTML('<label class="col-form-label col-sm-2" for="id_point">Point</label>', html)
+        self.assertIn('id="id_point_div_map"', html)


### PR DESCRIPTION
## Summary

`django.contrib.gis` has been in the test `INSTALLED_APPS` since the bootstrap4 days and CI installs GDAL, but **nothing has exercised a GIS form field here since the Bootstrap 5 rewrite**. [`d88bfe2`](../commit/d88bfe2) ("Render form fields in Bootstrap 5") dropped the import and the field, carrying over django-bootstrap3's commented-out state; the comment was removed later, leaving the `INSTALLED_APPS` entry and the GDAL install as vestige.

**Why this coverage is worth having.** A geometry widget builds its own template context from `attrs`. [Django #28105](https://code.djangoproject.com/ticket/28105) was a crash in exactly that path — `BaseGeometryWidget.get_context()` blew up when `attrs` carried a key the widget already used, which is precisely what a template pack does. That seam is bootstrap-specific, and it is live code here: recent changes forward per-option attrs and stop attrs leaking onto wrapper elements.

**Shape of the tests.** A dedicated file with explicit assertions, matching this repo's one-file-per-field-type layout — rather than django-bootstrap4's approach of dropping a `PointField` into a shared form and relying on bulk rendering to touch it. It also pins current behavior: the widget's serialized textarea keeps its own classes and does **not** get `form-control`, which is correct for a map widget but worth asserting so it cannot drift silently.

## Test plan

- [x] 158 tests pass (2 new), on Python 3.14 / Django 5.2.16
- [x] `just lint` passes
- [x] Verified the rendered output by hand first — the widget emits its own OpenLayers map markup wrapped in the bootstrap label and `mb-3` container

## Related

- zostera/django-bootstrap3#1140 removes the equivalent dead GDAL install and stale TODO there, where GIS is genuinely unused and the repo is in maintenance.
- django-bootstrap4 already has live GIS coverage and is unchanged.