### PR TITLE
Release 26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Drop support for Django 4.2 (EOL).
 - Add support for Django 6.1.
 - Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
-- Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
+- **Breaking:** Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
 - Fix `server_side_validation` not propagating from `bootstrap_form`/`bootstrap_formset` to field renderers (#612).
 - Fix placeholder being set on color and range inputs (#832).
 - Fix bugs in `url_replace_param`, jinja2 helpers, and `BaseRenderer.render`; add AGENTS.md (#830).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
 # Changelog
 
-## Unreleased
+## 26.3 (2026-08-28)
 
+- Drop support for Django 4.2 (EOL).
+- Add support for Django 6.1.
+- Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
+- Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
+- Fix `server_side_validation` not propagating from `bootstrap_form`/`bootstrap_formset` to field renderers (#612).
+- Fix placeholder being set on color and range inputs (#832).
+- Fix bugs in `url_replace_param`, jinja2 helpers, and `BaseRenderer.render`; add AGENTS.md (#830).
+- Add `label` argument to `bootstrap_field` to override a field's label text without touching the form definition — works with horizontal/floating layout and as the default placeholder (#635).
+- Add `label_class` setting so a default label CSS class can be set globally (#260).
+- Support `addon_before`/`addon_after` on `Select` widgets, excluding `SelectMultiple` and `RadioSelect` (#613).
+- Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).
+- Update default Bootstrap to 5.3.8.
+- Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
+- Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).
 - Add a maintenance-round section and release-note ordering convention to MAINTAINING.md.
 - Add tests for `django.contrib.gis` form field rendering.
 - Add a 15-minute `timeout-minutes` to every CI job.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `typos` spell checking to `just lint`.
-- Fix typos in `CHANGELOG.md` and `docs/settings.rst`.
-- Add `label` argument to `bootstrap_field` to override a field's label text without touching the form definition — works with horizontal/floating layout and as the default placeholder (#635).
-- Fix `size` docstrings for `bootstrap_field`/`bootstrap_form` and `bootstrap_pagination` — the documented values (`'small'`/`'medium'`/`'large'`) don't exist; the accepted values are `'sm'`/`'md'`/`'lg'` (#777).
-- Recognize `month` and `datetime-local` input-type widget subclasses as form-control widgets, enabling addons and floating labels for them (#309, #678).
-- Rewrite `radio_select.html` to forward each option's own attrs (fixing custom attrs like `data-total` from a custom `create_option()` being silently dropped on `RadioSelect`/`CheckboxSelectMultiple`, #300) and to stop leaking `disabled`/`required`/`form`/an always-empty `class=""` onto the non-form-control wrapper `<div>` (#806). Individual radio/checkbox inputs now correctly get `required`/`disabled`, matching Django's own default widget rendering, instead of only the wrapper having them.
-- Add `label_class` setting so a default label CSS class can be set globally (#260).
-- Support `addon_before`/`addon_after` on `Select` widgets, excluding `SelectMultiple` and `RadioSelect` (#613).
-- Fix `server_side_validation` not propagating from `bootstrap_form`/`bootstrap_formset` to field renderers (#612).
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
-- Add support for Django 6.1.
-- Add `layout` setting to set a default layout for forms and fields (#190, #531, thanks @blag).
-- Drop support for Django 4.2 (EOL).
-- Update default Bootstrap to 5.3.8.
-- Add `input_class` argument to `bootstrap_field` (#525, #535, thanks @frolenkov-nikita).
-- Warn when `layout="floating"` is used with `addon_before` or `addon_after` (#833).
-- Fix placeholder being set on color and range inputs (#832).
-- Fix bugs in `url_replace_param`, jinja2 helpers, and `BaseRenderer.render`; add AGENTS.md (#830).
+- Fix typos in `CHANGELOG.md` and `docs/settings.rst`.
+- Fix `size` docstrings for `bootstrap_field`/`bootstrap_form` and `bootstrap_pagination` — the documented values (`'small'`/`'medium'`/`'large'`) don't exist; the accepted values are `'sm'`/`'md'`/`'lg'` (#777).
 
 ## 26.2 (2026-02-08)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 name = "django-bootstrap5"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "26.3.dev0"
+version = "26.3"
 
 [project.optional-dependencies]
 jinja = ["Jinja2>=3.0,<4"]


### PR DESCRIPTION
## Summary

Stamps the Unreleased section as **26.3** and bumps `version` from `26.3.dev0` to `26.3`.

This is the release with real user impact — 47 commits since v26.2, including new arguments and settings, a rendering behavior change, and a Bootstrap default bump.

## Note ordering

The release notes are reordered so the support-matrix changes lead:

1. dropped Python/Django
2. added Python/Django
3. everything else, existing order preserved

Dropping Django 4.2 raises the dependency floor to `>=5.2` — a breaking change for anyone still on 4.2 — and it was sitting about twenty entries down where nobody would see it. Under the `YY.N` version scheme the number itself carries no breaking-change signal, so the note is the only warning those users get.

The reorder moves lines only; the set of entries is byte-identical before and after (verified by sorted-set diff).

## Highlights in this release

- **Breaking:** Django 4.2 support dropped, floor raised to `>=5.2`; Django 6.1 added
- `radio_select.html` rewritten — individual radio/checkbox inputs now get `required`/`disabled` matching Django's own rendering, and `disabled`/`required`/`form`/empty `class=""` no longer leak onto the wrapper `<div>` (#300, #806). **This changes rendered output.**
- New `label` and `input_class` arguments to `bootstrap_field` (#635, #525/#535)
- New `label_class` and `layout` settings (#260, #190/#531)
- `addon_before`/`addon_after` on `Select` widgets (#613)
- `month` / `datetime-local` recognized as form-control widgets (#309, #678)
- `server_side_validation` now propagates from `bootstrap_form`/`bootstrap_formset` (#612)
- Default Bootstrap updated to 5.3.8

## Test plan

- [x] `just lint` passes
- [x] `just build` passes end to end — build, twine, check-manifest, pyroma, check-wheel-contents, and both sdist/wheel smoke tests — producing `django_bootstrap5-26.3` artifacts
- [x] Entry set unchanged by the reorder (sorted diff is empty)
- [x] `## 26.2 (2026-02-08)` section boundary intact

## After merge

Per `MAINTAINING.md`: pull `main`, `just build`, then `just release-tag`.