### PR TITLE
Note in MAINTAINING.md why the Django dependency carries no upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Note in MAINTAINING.md why the `Django` dependency carries no upper bound.
+
 ## 26.3 (2026-08-28)
 
 - Drop support for Django 4.2 (EOL).

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -36,6 +36,15 @@ copy always drifts out of sync with the files that actually enforce it.
 - Don't hardcode a Bootstrap version number in prose docs. Point at `core.py` and the upstream
   releases page instead.
 
+Don't put an upper bound on the `Django` dependency. A cap does not produce a clean failure when a
+new Django major ships: the resolver backtracks to an older release of this package whose metadata
+never had one, so users silently get old, unmaintained code instead of an error. Verified — asking
+for `django-bootstrap4` with `django<5.2` resolves to `django-bootstrap4==26.1` with `django==5.1.15`,
+no error. Capping the current release cannot close a door that published metadata already left open.
+
+The `django-version: main` job in the CI matrix is the real early warning: it breaks while the new
+major is still in development, when there is time to fix and release.
+
 ## Maintenance round
 
 Start every maintenance round — and every release — by reconciling the support matrix with


### PR DESCRIPTION
## Summary

This repo has never had an upper bound on its `Django` dependency, so **nothing changes here functionally**. This documents *why*, so the rule does not drift back — django-marina and django-bootstrap4 had both grown a `<7.0` cap, which is being removed.

A cap cannot make an install fail on a new Django major. The resolver is free to backtrack to an older release of the package whose metadata never had one. Verified against live PyPI metadata:

```
$ uv pip compile  ("django-bootstrap4", "django<5.2")
django==5.1.15
django-bootstrap4==26.1     ← not an error. an old release.
```

So a cap does not buy a clean failure — it buys a silent downgrade to old, untested code. Capping the current release cannot close a door that already-published metadata left open.

The `django-version: main` job in the CI matrix is the actual early warning: it breaks while the next major is still in development, when there is still time to release.

## Test plan

- [x] `just lint` passes
- [x] Note verified byte-identical to django-marina's canonical version
- [x] Docs only — the `Django>=5.2` requirement is unchanged here