### PR TITLE
Add just release-check, and fix the stale release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `just release-check` to list `src/` changes against changelog entries before a release.
+- Fix the release process in MAINTAINING.md: the version bump goes through a PR, not a direct push to protected `main`.
 - Note in MAINTAINING.md why the `Django` dependency carries no upper bound.
 
 ## 26.3 (2026-08-28)

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -65,10 +65,16 @@ reality, not from memory:
 
 ## Release process
 
-1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
-2. Commit and push to `main`
-3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
-4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+1. `just release-check` — lists the commits touching `src/` since the last tag next to the current
+   `Unreleased` entries. Every one of those commits must be covered by an entry, or be a no-op for
+   users (a docstring typo, say). A code change that reaches users without an entry ships invisible.
+2. On a release branch, update `CHANGELOG.md` and bump `version` in `pyproject.toml`; open a PR and merge it
+3. Check out and pull `main`
+4. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
+5. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+
+`main` is protected — direct pushes are rejected (or bypass branch protection, which is worse). Always land the
+version bump through a PR like any other change.
 
 `just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.
 

--- a/justfile
+++ b/justfile
@@ -70,6 +70,17 @@ install:
         echo "Example not found."; \
     fi
 
+# Show src changes and changelog entries since the last tag (release preflight)
+@release-check:
+    TAG=$(git describe --tags --abbrev=0); \
+    echo "Commits touching src/ since $TAG:"; \
+    git log --format='  %h %s' "$TAG"..HEAD -- src/ | grep . || echo "  (none)"; \
+    echo ""; \
+    echo "Entries in the Unreleased section of CHANGELOG.md:"; \
+    awk '/^## Unreleased/{f=1;next} /^## /{f=0} f' CHANGELOG.md | grep '^- ' || echo "  (none)"; \
+    echo ""; \
+    echo "Every commit above must be covered by an entry, or be a no-op for users."
+
 # Create and push a release tag (publishing happens in GitHub Actions)
 @release-tag: porcelain branch build
     git tag -a v{{ VERSION }} -m "Release {{ VERSION }}"


### PR DESCRIPTION
## Summary

Propagated from django-marina ([zostera/django-marina#675](https://github.com/zostera/django-marina/pull/675)), the canonical source for shared tooling. Both the `justfile` recipe and the `MAINTAINING.md` release process are verbatim-synced per `PACKAGING.md`.

**Why it exists.** Two of the four releases on 2026-08-28 shipped code changes with **no changelog entry** — django-bootstrap4 a `KeyError` fix in `url_replace_param`, django-icons a `SafeString` rendering fix that was the most significant change in that release. Both were caught by hand, by diffing `src/` against the last tag. Nothing required that diff, and it takes several commands, so it does not get run mid-release. `just release-check` makes it one command and step 1.

It is deliberately **not** a pass/fail gate — changelog entries do not reference commits, so nothing can mechanically prove coverage — and deliberately **not** wired into `just build`, which runs in CI where a branch legitimately may not have its entry yet.

## Test plan

- [x] `just release-check` runs and reports correctly
- [x] `just lint` passes
- [x] Recipe and release-process block verified byte-identical to django-marina's

## Also: the release process here was stale

`MAINTAINING.md` in this repo still described the old flow:

```
1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
2. Commit and push to `main`
```

`main` is protected, so step 2 fails — or succeeds only by bypassing branch protection, which is worse. django-marina fixed this in #665 and it reached django-bootstrap3 and django-bootstrap4, but **never got propagated here**. The `` `main` is protected `` paragraph was missing too.

Since this PR replaces the release-process block wholesale to insert step 1, that drift is corrected in the same change — the block is now byte-identical to django-marina's.